### PR TITLE
Fitting actions to "Shared with me" view

### DIFF
--- a/packages/web-app-files/src/components/BatchActions.vue
+++ b/packages/web-app-files/src/components/BatchActions.vue
@@ -50,18 +50,32 @@
           <translate>Delete</translate>
         </oc-button>
       </div>
+      <div v-if="canAccept">
+        <oc-button id="accept-shares-btn" key="accept-shares-btn" @click="acceptShares()">
+          <oc-icon name="add" />
+          <translate>Accept</translate>
+        </oc-button>
+      </div>
+      <div v-if="canDecline">
+        <oc-button id="decline-shares-btn" key="decline-shares-btn" @click="declineShares()">
+          <oc-icon name="not_interested" />
+          <translate>Decline</translate>
+        </oc-button>
+      </div>
     </oc-grid>
   </div>
 </template>
 
 <script>
-import { mapGetters, mapActions } from 'vuex'
+import { mapGetters, mapActions, mapMutations } from 'vuex'
 
 import MixinRoutes from '../mixins/routes'
 import MixinDeleteResources from '../mixins/deleteResources'
 import { cloneStateObject } from '../helpers/store'
 import { canBeMoved } from '../helpers/permissions'
 import { checkRoute } from '../helpers/route'
+import { shareStatus } from '../helpers/shareStatus'
+import { buildSharedResource } from '../helpers/resources'
 
 export default {
   mixins: [MixinRoutes, MixinDeleteResources],
@@ -102,11 +116,39 @@ export default {
     },
 
     canDelete() {
-      if (this.isPublicFilesRoute) {
+      if (this.isPublicFilesRoute && !checkRoute(['files-shared-with-me'], this.$route.name)) {
         return this.currentFolder.canBeDeleted()
+      }
+      if (checkRoute(['files-shared-with-me'], this.$route.name)) {
+        return false
       }
 
       return true
+    },
+
+    canAccept() {
+      if (!checkRoute(['files-shared-with-me'], this.$route.name)) {
+        return false
+      }
+      let canAccept = true
+      this.selectedFiles.forEach(file => {
+        if (file.status === shareStatus.accepted) {
+          canAccept = false
+        }
+      })
+
+      return canAccept
+    },
+
+    canDecline() {
+      if (!checkRoute(['files-shared-with-me'], this.$route.name)) {
+        return false
+      }
+      let canDecline = true
+      this.selectedFiles.forEach(file => {
+        if (file.status === shareStatus.declined) canDecline = false
+      })
+      return canDecline
     },
 
     displayBulkActions() {
@@ -117,6 +159,12 @@ export default {
   methods: {
     ...mapActions('Files', ['removeFilesFromTrashbin', 'resetFileSelection', 'setHighlightedFile']),
     ...mapActions(['showMessage']),
+    ...mapMutations('Files', [
+      'LOAD_FILES',
+      'SELECT_RESOURCES',
+      'CLEAR_CURRENT_FILES_LIST',
+      'UPDATE_RESOURCE'
+    ]),
 
     restoreFiles(resources = this.selectedFiles) {
       for (const resource of resources) {
@@ -189,7 +237,70 @@ export default {
           })
         }
       })
+    },
+
+    // Lisas implementation
+    acceptShares() {
+      this.selectedFiles.forEach(resource => {
+        this.triggerShareAction(resource, 'POST')
+      })
+    },
+
+    declineShares() {
+      this.selectedFiles.forEach(resource => {
+        this.triggerShareAction(resource, 'DELETE')
+      })
+    },
+
+    async triggerShareAction(resource, type) {
+      try {
+        // exec share action
+        let response = await this.$client.requests.ocs({
+          service: 'apps/files_sharing',
+          action: `api/v1/shares/pending/${resource.share.id}`,
+          method: type
+        })
+        // exit on failure
+        if (response.status !== 200) {
+          throw new Error(response.statusText)
+        }
+        // get updated share from response or re-fetch it
+        let share = null
+        // oc10
+        if (parseInt(response.headers.get('content-length')) > 0) {
+          response = await response.json()
+          if (response.ocs.data.length > 0) {
+            share = response.ocs.data[0]
+          }
+        } else {
+          // ocis
+          const { shareInfo } = await this.$client.shares.getShare(resource.share.id)
+          share = shareInfo
+        }
+        // update share in store
+        if (share) {
+          const sharedResource = await buildSharedResource(
+            share,
+            true,
+            !this.isOcis,
+            this.configuration.server,
+            this.getToken
+          )
+          this.UPDATE_RESOURCE(sharedResource)
+        }
+      } catch (error) {
+        // this.loadResources()
+        this.showMessage({
+          title: this.$gettext('Error while changing share state'),
+          desc: error.message,
+          status: 'danger',
+          autoClose: {
+            enabled: true
+          }
+        })
+      }
     }
   }
 }
 </script>
+

--- a/packages/web-app-files/src/mixins/actions/delete.js
+++ b/packages/web-app-files/src/mixins/actions/delete.js
@@ -13,7 +13,7 @@ export default {
           },
           handler: this.$_delete_trigger,
           isEnabled: ({ resource }) => {
-            if (checkRoute(['files-trashbin'], this.$route.name)) {
+            if (checkRoute(['files-trashbin', 'files-shared-with-me'], this.$route.name)) {
               return false
             }
 

--- a/packages/web-app-files/src/mixins/actions/rename.js
+++ b/packages/web-app-files/src/mixins/actions/rename.js
@@ -15,7 +15,7 @@ export default {
           },
           handler: this.$_rename_trigger,
           isEnabled: ({ resource }) => {
-            if (checkRoute(['files-trashbin'], this.$route.name)) {
+            if (checkRoute(['files-trashbin', 'files-shared-with-me'], this.$route.name)) {
               return false
             }
 

--- a/packages/web-app-files/src/views/SharedWithMe.vue
+++ b/packages/web-app-files/src/views/SharedWithMe.vue
@@ -158,16 +158,15 @@
               :key="resource.id + resource.status"
               class="uk-text-nowrap uk-flex uk-flex-middle uk-flex-right"
             >
-              <oc-button
-                v-if="resource.status === 1 || resource.status === 0"
-                v-translate
-                appearance="raw"
-                size="small"
-                class="file-row-share-status-action uk-text-meta oc-ml"
-                @click.stop="triggerShareAction(resource, 'DELETE')"
-              >
-                Decline
-              </oc-button>
+               <oc-button
+                 v-if="[shareStatus.accepted, shareStatus.pending].includes(resource.status)"
+                 v-translate
+                 size="small"
+                 class="file-row-share-status-action oc-ml"
+                 @click.stop="triggerShareAction(resource, 'DELETE')"
+               >
+                 Decline
+               </oc-button>
               <span
                 class="uk-text-small oc-ml file-row-share-status-text uk-text-baseline"
                 v-text="getShareStatusText(resource.status)"
@@ -228,10 +227,10 @@
               class="uk-text-nowrap uk-flex uk-flex-middle uk-flex-right"
             >
               <oc-button
+                v-if="[shareStatus.declined, shareStatus.pending].includes(resource.status)"
                 v-translate
                 size="small"
-                variation="success"
-                class="file-row-share-status-action uk-text-meta"
+                class="file-row-share-status-action"
                 @click.stop="triggerShareAction(resource, 'POST')"
               >
                 Accept


### PR DESCRIPTION
## Description
- Button style for "Accept", "Delete" consistent in all 3 tables
- Batch actions "Accept", "Decline" for selected files (will need reimplementing of the function triggerShareAction, now it's implemented in sharedWithMe.vue (view) and copied to BatchActions.vue)
- Batch action "Delete" as well as bulk actions "Delete" and "Rename" deleted from "Shared with me"

