### PR TITLE
Fix projects router links

### DIFF
--- a/packages/web-app-files/src/index.js
+++ b/packages/web-app-files/src/index.js
@@ -123,7 +123,7 @@ const navItems = [
     iconMaterial: 'library_books',
     route: {
       name: 'projects',
-      path: `/${appInfo.id}/eos/project/`
+      path: `/${appInfo.id}/eos/project`
     }
   }
 ]
@@ -149,16 +149,6 @@ const routes = [
         meta: {
           hasBulkActions: true,
           title: $gettext('All files')
-        }
-      },
-      {
-        path: 'projects/:page?',
-        component: Projects,
-        name: 'projects',
-        meta: {
-          hideFilelistActions: true,
-          hasBulkActions: true,
-          title: $gettext('Projects')
         }
       },
       {
@@ -275,7 +265,6 @@ const routes = [
     },
     meta: { auth: false, title: $gettext('Public file upload') }
   },
-
   {
     name: 'eos',
     path: '/eos',
@@ -285,7 +274,7 @@ const routes = [
     children: [
       {
         name: 'project',
-        path: 'project',
+        path: 'project/:item?',
         component: Projects,
         meta: {
           hasBulkActions: false,

--- a/packages/web-app-files/src/views/Projects.vue
+++ b/packages/web-app-files/src/views/Projects.vue
@@ -201,7 +201,6 @@ export default {
               files: resources
             })
 
-            this.LOAD_FILES({ currentFolder: null, files: resources })
           }
           this.loading = false
         })
@@ -213,11 +212,13 @@ export default {
       /* For testing locally if no projects in the backend */
       const recievedResources = [
         {
-          name: '/example',
-          path: '/eos/project/e/example',
+          name: '/eos/project/e/example',
           permissions: 'admin'
         },
-        { name: '/fdo', path: '/eos/project/f/fdo', permissions: 'writer' }
+        {
+          name: '/eos/project/f/fdo',
+          permissions: 'writer'
+        }
       ]
 
       let resources = []
@@ -229,7 +230,6 @@ export default {
           type: 'dir',
           fileInfo: {
             '{http://owncloud.org/ns}permissions': 'RDNVCK',
-
             '{http://owncloud.org/ns}fileid': i + p.name,
             '{http://owncloud.org/ns}owner-id': 'einstein',
             '{http://owncloud.org/ns}owner-display-name': 'Albert Einstein',
@@ -246,8 +246,6 @@ export default {
         currentFolder: null,
         files: resources
       })
-
-      this.LOAD_FILES({ currentFolder: null, files: resources })
 
       this.loading = false
     }


### PR DESCRIPTION
## Description
Removes some dead code in the routes and duplicate LOAD_FILES calls and fixes some of the routing issues

Background: The `path` gets extracted from the `name` of a resource and the route was missing a dynamic `:item?`