### PR TITLE
Update sentry libraries, remove wildcard imports

### DIFF
--- a/packages/web-runtime/package.json
+++ b/packages/web-runtime/package.json
@@ -6,8 +6,8 @@
   "dependencies": {
     "@fortawesome/fontawesome-free": "^5.15.4",
     "@popperjs/core": "^2.4.0",
-    "@sentry/browser": "^5.30.0",
-    "@sentry/integrations": "^5.30.0",
+    "@sentry/browser": "^6.19.7",
+    "@sentry/integrations": "^6.19.7",
     "@vue/composition-api": "^1.4.9",
     "axios": "^0.26.1",
     "cross-fetch": "^3.0.6",

--- a/packages/web-runtime/src/container/bootstrap.ts
+++ b/packages/web-runtime/src/container/bootstrap.ts
@@ -15,8 +15,8 @@ import { unref } from '@vue/composition-api'
 import { useDefaultThemeName } from '../composables'
 import { clientService } from 'web-pkg/src/services'
 
-import * as Sentry from '@sentry/browser'
-import * as Integrations from '@sentry/integrations'
+import { init as SentryInit } from '@sentry/browser'
+import { Vue as SentryVueIntegration } from '@sentry/integrations'
 
 /**
  * fetch runtime configuration, this step is optional, all later steps can use a static
@@ -306,10 +306,11 @@ export const announceVersions = ({ store }: { store: Store<unknown> }): void => 
  */
 export const startSentry = (runtimeConfiguration: RuntimeConfiguration): void => {
   if (runtimeConfiguration.sentry?.dsn) {
-    Sentry.init({
+    SentryInit({
       dsn: runtimeConfiguration.sentry.dsn,
-      integrations: [new Integrations.Vue({ Vue, attachProps: true, logErrors: true })],
-      environment: runtimeConfiguration.sentry.environment || 'production'
+      integrations: [new SentryVueIntegration({ Vue, attachProps: true, logErrors: true })],
+      environment: runtimeConfiguration.sentry.environment || 'production',
+      autoSessionTracking: false
     })
   }
 }

--- a/packages/web-runtime/src/store/user.js
+++ b/packages/web-runtime/src/store/user.js
@@ -4,7 +4,7 @@ import initVueAuthenticate from '../services/auth'
 import { router } from '../router'
 import { clientService } from 'web-pkg/src/services'
 
-import * as Sentry from '@sentry/browser'
+import { setUser as sentrySetUser } from '@sentry/browser'
 
 let vueAuthInstance
 
@@ -252,7 +252,7 @@ const mutations = {
     state.isAuthenticated = user.isAuthenticated
     state.token = user.token
     state.groups = user.groups
-    Sentry.setUser({ username: user.id })
+    sentrySetUser({ username: user.id })
   },
   SET_CAPABILITIES(state, data) {
     state.capabilities = data.capabilities

--- a/yarn.lock
+++ b/yarn.lock
@@ -2163,79 +2163,79 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sentry/browser@npm:^5.30.0":
-  version: 5.30.0
-  resolution: "@sentry/browser@npm:5.30.0"
+"@sentry/browser@npm:^6.19.7":
+  version: 6.19.7
+  resolution: "@sentry/browser@npm:6.19.7"
   dependencies:
-    "@sentry/core": 5.30.0
-    "@sentry/types": 5.30.0
-    "@sentry/utils": 5.30.0
+    "@sentry/core": 6.19.7
+    "@sentry/types": 6.19.7
+    "@sentry/utils": 6.19.7
     tslib: ^1.9.3
-  checksum: 7fc154075c8f7da2ec54970cc0033555e4aa9ef88d2fc7fcfb2a0c206be5dca778914d5a25ddf06c5f8da8acffa9158a3ee2216b2efb848b75a3f11d281784db
+  checksum: 071d00c76c2d0384580474c634c58c6196bbd1a3cf510da1309bd1565c57df7422fca8ceb717db189fa557f2c711a21664ee1ab935dfd9869faf416d388e6f78
   languageName: node
   linkType: hard
 
-"@sentry/core@npm:5.30.0":
-  version: 5.30.0
-  resolution: "@sentry/core@npm:5.30.0"
+"@sentry/core@npm:6.19.7":
+  version: 6.19.7
+  resolution: "@sentry/core@npm:6.19.7"
   dependencies:
-    "@sentry/hub": 5.30.0
-    "@sentry/minimal": 5.30.0
-    "@sentry/types": 5.30.0
-    "@sentry/utils": 5.30.0
+    "@sentry/hub": 6.19.7
+    "@sentry/minimal": 6.19.7
+    "@sentry/types": 6.19.7
+    "@sentry/utils": 6.19.7
     tslib: ^1.9.3
-  checksum: 8a2b22687e70d76fa4381bce215d770b6c08561c5ff5d6afe39c8c3c509c18ee7384ad0be3aee18d3a858a3c88e1d2821cf10eb5e05646376a33200903b56da2
+  checksum: d212e8ef07114549de4a93b81f8bfa217ca1550ca7a5eeaa611e5629faef78ff72663ce561ffa2cff48f3dc556745ef65177044f9965cdd3cbccf617cf3bf675
   languageName: node
   linkType: hard
 
-"@sentry/hub@npm:5.30.0":
-  version: 5.30.0
-  resolution: "@sentry/hub@npm:5.30.0"
+"@sentry/hub@npm:6.19.7":
+  version: 6.19.7
+  resolution: "@sentry/hub@npm:6.19.7"
   dependencies:
-    "@sentry/types": 5.30.0
-    "@sentry/utils": 5.30.0
+    "@sentry/types": 6.19.7
+    "@sentry/utils": 6.19.7
     tslib: ^1.9.3
-  checksum: 09f778cc78765213f1e35a3ee6da3a8e02a706e8a7e5b7f84614707f4b665c7297b700a1849ab2ca1f02ede5884fd9ae893e58dc65f04f35ccdfee17e99ee93d
+  checksum: 10bb1c5cba1b0f1e27a3dd0a186c22f94aeaf11c4662890ab07b2774f46f46af78d61e3ba71d76edc750a7b45af86edd032f35efecdb4efa2eaf551080ccdcb1
   languageName: node
   linkType: hard
 
-"@sentry/integrations@npm:^5.30.0":
-  version: 5.30.0
-  resolution: "@sentry/integrations@npm:5.30.0"
+"@sentry/integrations@npm:^6.19.7":
+  version: 6.19.7
+  resolution: "@sentry/integrations@npm:6.19.7"
   dependencies:
-    "@sentry/types": 5.30.0
-    "@sentry/utils": 5.30.0
-    localforage: 1.8.1
+    "@sentry/types": 6.19.7
+    "@sentry/utils": 6.19.7
+    localforage: ^1.8.1
     tslib: ^1.9.3
-  checksum: c9436f76ca829b87359f3492e1c6131d8adaa8a0287d968f72588237ad13d9ac7bf060f48c3acd41283257f63dd6506ed1579373a0bcdb5d6cfbaa355687205f
+  checksum: 6ea22ef8d518e6ade96ad00c07f5346c8316264ae6ec353c299e03d1d3cf4b226f639bde07dd5d1da28feaa031338e75df25fc60a083a24d847f4cfde4dbc8e9
   languageName: node
   linkType: hard
 
-"@sentry/minimal@npm:5.30.0":
-  version: 5.30.0
-  resolution: "@sentry/minimal@npm:5.30.0"
+"@sentry/minimal@npm:6.19.7":
+  version: 6.19.7
+  resolution: "@sentry/minimal@npm:6.19.7"
   dependencies:
-    "@sentry/hub": 5.30.0
-    "@sentry/types": 5.30.0
+    "@sentry/hub": 6.19.7
+    "@sentry/types": 6.19.7
     tslib: ^1.9.3
-  checksum: 934650f6989ce51f425c7c4b4d4d9bfecface8162a36d21df8a241f780ab1716dd47b81e2170e4cc624797ed1eebe10f71e4876c1e25b787860daaef75ca7a0c
+  checksum: 9153ac426ee056fc34c5be898f83d74ec08f559d69f544c5944ec05e584b62ed356b92d1a9b08993a7022ad42b5661c3d72881221adc19bee5fc1af3ad3864a8
   languageName: node
   linkType: hard
 
-"@sentry/types@npm:5.30.0":
-  version: 5.30.0
-  resolution: "@sentry/types@npm:5.30.0"
-  checksum: de7df777824c8e311f143c6fd7de220b24f25b5018312fe8f67d93bebf0f3cdd32bbca9f155846f5c31441d940eebe27c8338000321559a743264c7e41dda560
+"@sentry/types@npm:6.19.7":
+  version: 6.19.7
+  resolution: "@sentry/types@npm:6.19.7"
+  checksum: f46ef74a33376ad6ea9b128115515c58eb9369d89293c60aa67abca26b5d5d519aa4d0a736db56ae0d75ffd816643d62187018298523cbc2e6c2fb3a6b2a9035
   languageName: node
   linkType: hard
 
-"@sentry/utils@npm:5.30.0":
-  version: 5.30.0
-  resolution: "@sentry/utils@npm:5.30.0"
+"@sentry/utils@npm:6.19.7":
+  version: 6.19.7
+  resolution: "@sentry/utils@npm:6.19.7"
   dependencies:
-    "@sentry/types": 5.30.0
+    "@sentry/types": 6.19.7
     tslib: ^1.9.3
-  checksum: 27b259a136c664427641dd32ee3dc490553f3b5e92986accfa829d14063ebc69b191e92209ac9c40fbc367f74cfa17dc93b4c40981d666711fd57b4d51a82062
+  checksum: a000223b9c646c64e3565e79cace1eeb75114342b768367c4dddd646476c215eb1bddfb70c63f05e2352d3bce2d7d415344e4757a001605d0e01ac74da5dd306
   languageName: node
   linkType: hard
 
@@ -8745,12 +8745,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"localforage@npm:1.8.1":
-  version: 1.8.1
-  resolution: "localforage@npm:1.8.1"
+"localforage@npm:^1.8.1":
+  version: 1.10.0
+  resolution: "localforage@npm:1.10.0"
   dependencies:
     lie: 3.1.1
-  checksum: 1d2846bfdbbf14f3df0cc04350ac7663abcec6799bff3f1f33dc32bdc64e6cf03adb5e82cdc967291503dfdc104946c7fba4642748fe70d21aef3901b755e2f8
+  checksum: f2978b434dafff9bcb0d9498de57d97eba165402419939c944412e179cab1854782830b5ec196212560b22712d1dd03918939f59cf1d4fc1d756fca7950086cf
   languageName: node
   linkType: hard
 
@@ -13910,8 +13910,8 @@ __metadata:
   dependencies:
     "@fortawesome/fontawesome-free": ^5.15.4
     "@popperjs/core": ^2.4.0
-    "@sentry/browser": ^5.30.0
-    "@sentry/integrations": ^5.30.0
+    "@sentry/browser": ^6.19.7
+    "@sentry/integrations": ^6.19.7
     "@types/luxon": ^2.0.8
     "@types/semver": ^7.3.8
     "@vue/composition-api": ^1.4.9


### PR DESCRIPTION
This PR addresses the problems raised in https://github.com/owncloud/web/pull/6759#pullrequestreview-935724673, except for the wildcard import of Vue (which I'm not sure can be avoided).

I found out setting autoSessionTracking: false in the Sentry options (as shown in [the changelog](https://github.com/getsentry/sentry-javascript/releases/tag/6.0.0) seem to avoid sending the message causing the errors.