### PR TITLE
Extensible Sentry config

### DIFF
--- a/packages/web-runtime/src/container/bootstrap.ts
+++ b/packages/web-runtime/src/container/bootstrap.ts
@@ -319,11 +319,17 @@ export const announceVersions = ({ store }: { store: Store<unknown> }): void => 
  */
 export const startSentry = (runtimeConfiguration: RuntimeConfiguration): void => {
   if (runtimeConfiguration.sentry?.dsn) {
+    const {
+      dsn,
+      environment = 'production',
+      ...moreSentryOptions
+    } = runtimeConfiguration.sentry;
+
     SentryInit({
-      dsn: runtimeConfiguration.sentry.dsn,
+      dsn,
+      environment,
       integrations: [new SentryVueIntegration({ Vue, attachProps: true, logErrors: true })],
-      environment: runtimeConfiguration.sentry.environment || 'production',
-      autoSessionTracking: false
+      ...moreSentryOptions,
     })
   }
 }


### PR DESCRIPTION
This PR extends the Sentry Init options object to include all fields found in the `sentry` section of the `config.json` file.

Note we now have to include `autoSessionTracking: false` there to avoid errors using our Sentry instance.