### PR TITLE
CERN-specific config flag + share tooltip captions

### DIFF
--- a/changelog/unreleased/enhancement-cern-features
+++ b/changelog/unreleased/enhancement-cern-features
@@ -1,0 +1,3 @@
+Enhancement: CERN features setting
+
+We've added a flag to enable CERN-specific features

--- a/changelog/unreleased/enhancement-cern-specific-help-in-shares-tooltip
+++ b/changelog/unreleased/enhancement-cern-specific-help-in-shares-tooltip
@@ -1,0 +1,3 @@
+Enhancement: CERN-specific help in shares tooltip
+
+We've added some CERN-related help strings to the share tooltip.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -57,6 +57,7 @@ substring of a value of the authenticated user. Examples are `/Shares`, `/{{.Id}
 - `options.sharingRecipientsPerPage` Sets the amount of users shown as recipients in the dropdown when sharing resources. Default amount is 200.
 - `options.sidebar.shares.showAllOnLoad` Sets the list of (link) shares list in the sidebar to be initially expanded (default is a collapsed state, only showing the first three shares).
 - `options.runningOnEos` Set this option to `true` if running on an [EOS storage backend](https://eos-web.web.cern.ch/eos-web/) to enable its specific features. Defaults to `false`.
+- `options.cernFeatures` Enabling this will activate CERN-specific features. Defaults to `false`.
 
 ### Sentry
 

--- a/packages/web-app-files/src/components/SideBar/Shares/Collaborators/InviteCollaborator/InviteCollaboratorForm.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/Collaborators/InviteCollaborator/InviteCollaboratorForm.vue
@@ -95,6 +95,7 @@ import { clientService } from 'web-pkg/src/services'
 import { useCapabilityFilesSharingResharing } from 'web-pkg/src/composables'
 import {
   shareInviteCollaboratorHelp,
+  shareInviteCollaboratorHelpCern,
   shareSpaceAddMemberHelp
 } from '../../../../../helpers/contextualHelpers.js'
 
@@ -147,7 +148,13 @@ export default {
     },
 
     inviteCollaboratorHelp() {
-      return shareInviteCollaboratorHelp
+      const cernFeatures = !!this.configuration?.options?.cernFeatures
+      return cernFeatures
+        ? {
+            text: shareInviteCollaboratorHelp.text,
+            list: [...shareInviteCollaboratorHelp.list, ...shareInviteCollaboratorHelpCern.list]
+          }
+        : shareInviteCollaboratorHelp
     },
 
     spaceAddMemberHelp() {
@@ -155,14 +162,10 @@ export default {
     },
 
     inviteDescriptionMessage() {
-      if (this.capabilities.files_sharing.federation?.outgoing === true) {
-        return this.$gettext('Add new person by name, email, service/secondary/guest accounts, or federation IDs')
-      }
-      return this.$gettext('Add new person by name, email or service/secondary/guest accounts')
-    },
-
-    $_announcementWhenCollaboratorAdded() {
-      return this.$gettext('Person was added')
+      const cernFeatures = !!this.configuration?.options?.cernFeatures
+      return cernFeatures
+        ? this.$gettext('Add new person by name, email or service/secondary/guest accounts')
+        : this.$gettext('Add new person by name, email or federation IDs')
     },
 
     $_isValid() {

--- a/packages/web-app-files/src/helpers/contextualHelpers.js
+++ b/packages/web-app-files/src/helpers/contextualHelpers.js
@@ -9,15 +9,19 @@ export const empty = {
 export const shareInviteCollaboratorHelp = {
   text: $gettext('Invite persons or groups to access this file or folder.'),
   list: [
-    $gettext(
-      'To search for service or secondary accounts prefix the username with "a:" (like "a:doe") and for guest accounts prefix the username with "l:" (like "l:doe")'
-    ),
     $gettext('Enter a name or group to share this item'),
     $gettext(
       'If you share a folder,  all of its contents and subfolders will be shared with the entered persons or groups'
     ),
     $gettext('Invited persons or groups will be notified via e-mail or in-app notification'),
     $gettext('Invited persons can not see who else has access')
+  ]
+}
+export const shareInviteCollaboratorHelpCern = {
+  list: [
+    $gettext(
+      'To search for service or secondary accounts prefix the username with "a:" (like "a:doe") and for guest accounts prefix the username with "l:" (like "l:doe")'
+    )
   ]
 }
 export const shareSpaceAddMemberHelp = {

--- a/packages/web-runtime/src/store/config.js
+++ b/packages/web-runtime/src/store/config.js
@@ -49,6 +49,7 @@ const state = {
     },
     previewFileExtensions: [],
     runningOnEos: false,
+    cernFeatures: false,
     sharingRecipientsPerPage: 200
   }
 }


### PR DESCRIPTION
This PR adds a `cernFeatures` config flag we can use from here on to add our CERN-branded stuff upstream.

Using that, it also displays different info on the shares tool-tip.