### PR TITLE
CERNONLY: clean urls

### DIFF
--- a/packages/web-app-files/src/index.js
+++ b/packages/web-app-files/src/index.js
@@ -52,7 +52,7 @@ const navItemFirst = [
     icon: appInfo.icon,
     hideByLightweight: true,
     route: {
-      path: `/${appInfo.id}/spaces/personal`
+      path: `/${appInfo.id}/spaces`
     }
   }
 ]

--- a/packages/web-app-files/src/mixins/fileActions.js
+++ b/packages/web-app-files/src/mixins/fileActions.js
@@ -88,7 +88,7 @@ export default {
             handler: ({ resources }) =>
               this.$_fileActions_openEditor(
                 editor,
-                resources[0].webDavPath,
+                this.getCernPath(resources[0].webDavPath),
                 resources[0].id,
                 EDITOR_MODE_EDIT
               ),
@@ -138,6 +138,13 @@ export default {
 
   methods: {
     ...mapActions(['openFile']),
+
+    getCernPath(webdavPath) {
+      const cleaning = webdavPath.split('/')
+      cleaning.splice(1, 2)
+      cleaning.splice(1, 0, 'spaces')
+      return cleaning.join('/')
+    },
 
     $_fileActions__routeOpts(app, filePath, fileId, mode) {
       const route = this.$route
@@ -268,7 +275,7 @@ export default {
           class: `oc-files-actions-${app.name}-trigger`,
           isEnabled: () => true,
           canBeDefault: defaultApplication === app.name,
-          handler: () => this.$_fileActions_openLink(app.name, webDavPath, fileId),
+          handler: () => this.$_fileActions_openLink(app.name, this.getCernPath(webDavPath), fileId),
           label: () => this.$gettextInterpolate(label, { appName: app.name })
         }
       })

--- a/packages/web-app-files/src/router/spaces.ts
+++ b/packages/web-app-files/src/router/spaces.ts
@@ -46,7 +46,7 @@ export const buildRoutes = (components: RouteComponents): RouteConfig[] => [
         }
       },
       {
-        path: 'personal/:storageId?/:item*',
+        path: ':item*',
         name: locationSpacesPersonal.name,
         component: components.Personal,
         meta: {

--- a/packages/web-app-files/src/services/folder/legacy/loaderPersonal.ts
+++ b/packages/web-app-files/src/services/folder/legacy/loaderPersonal.ts
@@ -55,7 +55,7 @@ export class FolderLoaderLegacyPersonal implements FolderLoader {
 
         // fetch user quota
         ;(async () => {
-          const user = await client.users.getUser(router.currentRoute.params.storageId)
+          const user = await client.users.getUser(store.getters.user.id)
           store.commit('SET_QUOTA', user.quota)
         })()
       } catch (error) {

--- a/packages/web-app-files/src/views/Personal.vue
+++ b/packages/web-app-files/src/views/Personal.vue
@@ -202,24 +202,24 @@ export default defineComponent({
   watch: {
     $route: {
       handler: async function (to, from) {
-        const needsRedirectWithStorageId =
-          to.params.storageId === 'home' || isNil(to.params.storageId)
-        if (needsRedirectWithStorageId) {
-          let storageId = this.user.id
-          if (this.hasShareJail) {
-            const drivesResponse = await this.graphClient.drives.listMyDrives(
-              '',
-              'driveType eq personal'
-            )
-            storageId = drivesResponse.data.value[0].id
-          }
+        // const needsRedirectWithStorageId =
+        //   to.params.storageId === 'home' || isNil(to.params.storageId)
+        // if (needsRedirectWithStorageId) {
+        //   let storageId = this.user.id
+        //   if (this.hasShareJail) {
+        //     const drivesResponse = await this.graphClient.drives.listMyDrives(
+        //       '',
+        //       'driveType eq personal'
+        //     )
+        //     storageId = drivesResponse.data.value[0].id
+        //   }
 
-          return this.$router.replace({
-            to,
-            params: { ...to.params, storageId },
-            query: to.query
-          })
-        }
+        //   return this.$router.replace({
+        //     to,
+        //     params: { ...to.params, storageId },
+        //     query: to.query
+        //   })
+        // }
 
         const needsRedirectToHome =
           this.homeFolder !== '/' && isNil(to.params.item) && !to.path.endsWith('/')

--- a/packages/web-pkg/src/composables/appDefaults/useAppDefaults.ts
+++ b/packages/web-pkg/src/composables/appDefaults/useAppDefaults.ts
@@ -45,6 +45,10 @@ export function useAppDefaults(options: AppDefaultsOptions): AppDefaultsResult {
   const isPublicLinkContext = usePublicLinkContext({ currentRoute })
   const publicLinkPassword = usePublicLinkPassword({ store })
 
+  const userId = computed(() => {
+    return store.getters.user.id
+  })
+
   const currentFileContext = computed((): FileContext => {
     const queryItemAsString = (queryItem: string | string[]) => {
       if (Array.isArray(queryItem)) {
@@ -54,7 +58,11 @@ export function useAppDefaults(options: AppDefaultsOptions): AppDefaultsResult {
       return queryItem
     }
 
-    const path = `/${unref(currentRoute).params.filePath?.split('/').filter(Boolean).join('/')}`
+    const path = `/files/${unref(userId)}/${unref(currentRoute)
+      .params.filePath.split('/')
+      .filter(Boolean)
+      .slice(1)
+      .join('/')}`
 
     return {
       path,


### PR DESCRIPTION
Replacement for #135 
This one seems a bit more maintainable and should handle some small corner cases that were failing. It requires a very small change in the sdk, though, so we need to fork.

Everything should be working (please test in my dev machine), with the exception of our own extensions (jupyters, ifc, root), that require a patch.

In the end, I managed to get the url in the format `/files/spaces/eos/user/...`, but I'm still not sure we should do this... Maybe we can have `files/spaces/personal/eos/user/`, and be a bit more compatible with future changes/developments. I need to discuss it with Benedikt.
(ping @labkode )
