### PR TITLE
EOS Windows path in file details

### DIFF
--- a/packages/web-app-files/src/components/SideBar/Details/FileDetails.vue
+++ b/packages/web-app-files/src/components/SideBar/Details/FileDetails.vue
@@ -322,16 +322,16 @@ export default defineComponent({
       return this.$gettext('Copy direct link')
     },
     eosFusePathLabel() {
-      return this.$gettext('EOS FUSE Path')
+      return this.$gettext('EOS Path')
     },
     copyEosFusePathLabel() {
-      return this.$gettext('Copy EOS FUSE path')
+      return this.$gettext('Copy EOS path')
     },
     eosWindowsPathLabel() {
-      return this.$gettext('EOS Windows Path')
+      return this.$gettext('Windows Path')
     },
     copyEosWindowsPathLabel() {
-      return this.$gettext('Copy EOS Windows path')
+      return this.$gettext('Copy Windows path')
     },
     showSize() {
       return this.getResourceSize(this.file.size) !== '?'
@@ -470,8 +470,8 @@ export default defineComponent({
       this.copiedEosFuse = true
       this.clipboardSuccessHandler()
       this.showMessage({
-        title: this.$gettext('EOS FUSE path copied'),
-        desc: this.$gettext('The EOS FUSE path has been copied to your clipboard.')
+        title: this.$gettext('EOS path copied'),
+        desc: this.$gettext('The EOS path has been copied to your clipboard.')
       })
     },
     copyEosWindowsPathToClipboard() {
@@ -479,8 +479,8 @@ export default defineComponent({
       this.copiedEosWindows = true
       this.clipboardSuccessHandler()
       this.showMessage({
-        title: this.$gettext('EOS Windows path copied'),
-        desc: this.$gettext('The EOS Windows path has been copied to your clipboard.')
+        title: this.$gettext('Windows path copied'),
+        desc: this.$gettext('The Windows path has been copied to your clipboard.')
       })
     },
     getEosWindowsPath(path) {

--- a/packages/web-app-files/src/helpers/path/pathMappings.ts
+++ b/packages/web-app-files/src/helpers/path/pathMappings.ts
@@ -1,0 +1,6 @@
+export default {
+  user: 'cernbox-smb\\eos\\user',
+  project: 'eosproject-smb\\eos\\project',
+  public: 'eospublic-smb\\eos',
+  media: 'eosmedia-smb\\eos'
+}


### PR DESCRIPTION
- Added "EOS Windows path" property for file details in the sidebar
- Added copy function for this path

From Jira ticket:

As a Windows user, it would be convenient to have access to a Windows-friendly path, not only to the Linux-style EOS path, when opening the details of a file in the web UI.

To implement this, we need to keep somewhere as static information a map such as:

/eos/user -> \\cernbox-smb\eos\user
/eos/project -> \\eosproject-smb\eos\project
/eos/public/opendata -> \\eospublic-smb\eos\opendata