### PR TITLE
Hide sidebar paths in public links

### DIFF
--- a/packages/web-app-files/src/components/SideBar/Details/FileDetails.vue
+++ b/packages/web-app-files/src/components/SideBar/Details/FileDetails.vue
@@ -134,7 +134,7 @@
             </div>
           </td>
         </tr>
-        <tr v-if="runningOnEos && !isPublic">
+        <tr v-if="runningOnEos">
           <th scope="col" class="oc-pr-s" v-text="directLinkLabel" />
           <td>
             <div class="oc-flex oc-flex-middle oc-flex-between oc-width-1-1">
@@ -318,7 +318,9 @@ export default defineComponent({
       return this.file.owner?.[0].additionalInfo
     },
     directLink() {
-      return `${this.configuration.server}files/spaces${encodePath(this.file.path)}`
+      return !this.isPublic
+        ? `${this.configuration.server}files/spaces${encodePath(this.file.path)}`
+        : `${this.configuration.server.replace(/\/+$/, '')}${this.file.downloadURL}`
     },
     directLinkLabel() {
       return this.$gettext('Direct link')
@@ -327,10 +329,10 @@ export default defineComponent({
       return this.$gettext('Copy direct link')
     },
     eosPathLabel() {
-      return this.$gettext('EOS Path')
+      return this.$gettext('FUSE Path')
     },
     copyEosPathLabel() {
-      return this.$gettext('Copy EOS path')
+      return this.$gettext('Copy FUSE path')
     },
     sambaPathLabel() {
       return this.$gettext('Windows Path')
@@ -475,8 +477,8 @@ export default defineComponent({
       this.copiedEos = true
       this.clipboardSuccessHandler()
       this.showMessage({
-        title: this.$gettext('EOS path copied'),
-        desc: this.$gettext('The EOS path has been copied to your clipboard.')
+        title: this.$gettext('FUSE path copied'),
+        desc: this.$gettext('The FUSE path has been copied to your clipboard.')
       })
     },
     copySambaPathToClipboard() {

--- a/packages/web-app-files/src/components/SideBar/Details/FileDetails.vue
+++ b/packages/web-app-files/src/components/SideBar/Details/FileDetails.vue
@@ -78,7 +78,7 @@
             />
           </td>
         </tr>
-        <tr v-if="runningOnEos">
+        <tr v-if="runningOnEos && !isPublic">
           <th scope="col" class="oc-pr-s" v-text="eosPathLabel" />
           <td>
             <div class="oc-flex oc-flex-middle oc-flex-between oc-width-1-1">
@@ -106,7 +106,7 @@
             </div>
           </td>
         </tr>
-        <tr v-if="cernFeatures && getSambaPath(file.path)">
+        <tr v-if="cernFeatures && getSambaPath(file.path) && !isPublic">
           <th scope="col" class="oc-pr-s" v-text="sambaPathLabel" />
           <td>
             <div class="oc-flex oc-flex-middle oc-flex-between oc-width-1-1">
@@ -134,7 +134,7 @@
             </div>
           </td>
         </tr>
-        <tr v-if="runningOnEos">
+        <tr v-if="runningOnEos && !isPublic">
           <th scope="col" class="oc-pr-s" v-text="directLinkLabel" />
           <td>
             <div class="oc-flex oc-flex-middle oc-flex-between oc-width-1-1">
@@ -245,6 +245,9 @@ export default defineComponent({
         this.showShares ||
         this.showVersions
       )
+    },
+    isPublic() {
+      return !isAuthenticatedRoute(this.$route)
     },
     noContentText() {
       return this.$gettext('No information to display')

--- a/packages/web-app-files/tests/unit/components/SideBar/Details/__snapshots__/FileDetails.spec.js.snap
+++ b/packages/web-app-files/tests/unit/components/SideBar/Details/__snapshots__/FileDetails.spec.js.snap
@@ -201,11 +201,11 @@ exports[`Details SideBar Panel displays a resource of type file on a private pag
       </tr>
       <!---->
       <tr>
-        <th scope="col" class="oc-pr-s">EOS Path</th>
+        <th scope="col" class="oc-pr-s">FUSE Path</th>
         <td>
           <div class="oc-flex oc-flex-middle oc-flex-between oc-width-1-1">
             <p class="oc-my-rm oc-text-truncate">/Shares/123.png</p>
-            <oc-button-stub aria-label="Copy EOS path" appearance="raw" variation="passive">
+            <oc-button-stub aria-label="Copy FUSE path" appearance="raw" variation="passive">
               <oc-icon-stub name="clipboard"></oc-icon-stub>
             </oc-button-stub>
           </div>
@@ -293,11 +293,11 @@ exports[`Details SideBar Panel displays a resource of type file on a public page
       </tr>
       <!---->
       <tr>
-        <th scope="col" class="oc-pr-s">EOS Path</th>
+        <th scope="col" class="oc-pr-s">FUSE Path</th>
         <td>
           <div class="oc-flex oc-flex-middle oc-flex-between oc-width-1-1">
             <p class="oc-my-rm oc-text-truncate">/Shares/123.png</p>
-            <oc-button-stub aria-label="Copy EOS path" appearance="raw" variation="passive">
+            <oc-button-stub aria-label="Copy FUSE path" appearance="raw" variation="passive">
               <oc-icon-stub name="clipboard"></oc-icon-stub>
             </oc-button-stub>
           </div>
@@ -415,11 +415,11 @@ exports[`Details SideBar Panel displays a resource of type folder on a private p
       </tr>
       <!---->
       <tr>
-        <th scope="col" class="oc-pr-s">EOS Path</th>
+        <th scope="col" class="oc-pr-s">FUSE Path</th>
         <td>
           <div class="oc-flex oc-flex-middle oc-flex-between oc-width-1-1">
             <p class="oc-my-rm oc-text-truncate"></p>
-            <oc-button-stub aria-label="Copy EOS path" appearance="raw" variation="passive">
+            <oc-button-stub aria-label="Copy FUSE path" appearance="raw" variation="passive">
               <oc-icon-stub name="clipboard"></oc-icon-stub>
             </oc-button-stub>
           </div>
@@ -503,11 +503,11 @@ exports[`Details SideBar Panel displays a resource of type folder on a public pa
       </tr>
       <!---->
       <tr>
-        <th scope="col" class="oc-pr-s">EOS Path</th>
+        <th scope="col" class="oc-pr-s">FUSE Path</th>
         <td>
           <div class="oc-flex oc-flex-middle oc-flex-between oc-width-1-1">
             <p class="oc-my-rm oc-text-truncate"></p>
-            <oc-button-stub aria-label="Copy EOS path" appearance="raw" variation="passive">
+            <oc-button-stub aria-label="Copy FUSE path" appearance="raw" variation="passive">
               <oc-icon-stub name="clipboard"></oc-icon-stub>
             </oc-button-stub>
           </div>


### PR DESCRIPTION
This PR hides EOS path and Samba path in sidebar when visiting a public link. Also, it shows the correct direct link in those.