### PR TITLE
CERNONLY: riderect to '/' instead of accessDenied

### DIFF
--- a/packages/web-runtime/src/services/auth/authService.ts
+++ b/packages/web-runtime/src/services/auth/authService.ts
@@ -82,7 +82,7 @@ export class AuthService {
         await this.resetStateAfterUserLogout()
 
         if (this.userManager.unloadReason === 'authError') {
-          return this.router.push({ name: 'accessDenied' })
+          return this.router.push('/') // this.router.push({ name: 'accessDenied' })
         }
 
         // handle redirect after logout
@@ -179,6 +179,7 @@ export class AuthService {
       return this.userManager.signoutRedirect({ id_token_hint: u.id_token })
     } else {
       await this.userManager.removeUser()
+
     }
   }
 


### PR DESCRIPTION
Added redirecting to '/' that:
- redirects to the authentication page if  the auth token is not valid anymore and there is now new access token
- performs automatic login if a new access token is available (the user did a logout and login again outside of CERNBox)