### PR TITLE
Fix crash on bad egroups

### DIFF
--- a/packages/web-app-files/src/components/SideBar/Shares/FileShares.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/FileShares.vue
@@ -190,7 +190,11 @@ export default {
     },
 
     collaborators() {
-      return [...this.currentFileOutgoingCollaborators, ...this.indirectOutgoingShares]
+      // filter out bad egroups
+      return [
+        ...this.currentFileOutgoingCollaborators.filter(e => e.collaborator.displayName || e.displayName),
+        ...this.indirectOutgoingShares.filter(e => e.collaborator.displayName || e.displayName),
+      ]
         .sort(this.collaboratorsComparator)
         .map((collaborator) => {
           collaborator.key = 'collaborator-' + collaborator.id


### PR DESCRIPTION
This PR fixes the sidebar crashing when a share invitee is an e-group with wrong data. When the backend sends incorrect information the `displayName` will not be present and so the group can be filtered to at least avoid the web crashing.

The origin of these broken egroups should be fixed too as the web will not be showing a part of the invitees if they are sent in that state.