### PR TITLE
Improve share UX

### DIFF
--- a/packages/web-app-files/src/components/SideBar/Shares/Collaborators/InviteCollaborator/InviteCollaboratorForm.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/Collaborators/InviteCollaborator/InviteCollaboratorForm.vue
@@ -58,18 +58,19 @@
         <oc-spinner :aria-label="$gettext('Creating share')" size="small" />
         <span v-translate :aria-hidden="true" v-text="saveButtonLabel" />
       </oc-button>
-      <oc-button
-        v-else
-        id="new-collaborators-form-create-button"
-        key="new-collaborator-save-button"
-        data-testid="new-collaborators-form-create-button"
-        :disabled="!$_isValid"
-        variation="primary"
-        appearance="filled"
-        submit="submit"
-        @click="share"
-        v-text="$gettext(saveButtonLabel)"
-      />
+      <span v-else v-oc-tooltip="saveButtonTooltip">
+        <oc-button
+          id="new-collaborators-form-create-button"
+          key="new-collaborator-save-button"
+          data-testid="new-collaborators-form-create-button"
+          :disabled="!$_isValid"
+          variation="primary"
+          appearance="filled"
+          submit="submit"
+          @click="share"
+          v-text="saveButtonLabel"
+        />
+      </span>
     </div>
     <oc-hidden-announcer level="assertive" :announcement="announcement" />
   </div>
@@ -153,6 +154,14 @@ export default defineComponent({
       return this.configuration?.options?.contextHelpers
     },
 
+    saveButtonTooltip() {
+      if (!this.selectedCollaborators.length) {
+        return $gettext('Add some people')
+      } else if (!this.selectedRole) {
+        return $gettext('Select a role')
+      }
+    },
+
     inviteCollaboratorHelp() {
       const cernFeatures = !!this.configuration?.options?.cernFeatures
       return cernFeatures
@@ -182,7 +191,7 @@ export default defineComponent({
     },
 
     $_isValid() {
-      return this.selectedCollaborators.length > 0
+      return this.selectedCollaborators.length && this.selectedRole
     },
 
     minSearchLength() {
@@ -198,10 +207,6 @@ export default defineComponent({
   },
   mounted() {
     this.fetchRecipients = debounce(this.fetchRecipients, 500)
-
-    this.selectedRole = this.resourceIsSpace
-      ? SpacePeopleShareRoles.list()[0]
-      : PeopleShareRoles.list(this.highlightedFile.isFolder)[0]
   },
 
   methods: {

--- a/packages/web-app-files/src/components/SideBar/Shares/Collaborators/RoleDropdown.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/Collaborators/RoleDropdown.vue
@@ -1,5 +1,5 @@
 <template>
-  <span v-if="selectedRole" class="oc-flex oc-flex-middle">
+  <span class="oc-flex oc-flex-middle">
     <span v-if="availableRoles.length === 1">
       <span v-if="!existingRole" v-text="inviteLabel" />
       <span v-else>{{ $gettext(selectedRole.label) }}</span>
@@ -141,6 +141,9 @@ export default {
       return this.$gettext('Select role for the invitation')
     },
     inviteLabel() {
+      if (!this.selectedRole) {
+        return this.$gettext('Select a role...')
+      }
       if (this.selectedRole.hasCustomPermissions) {
         return this.$gettext('Invite with custom permissions')
       } else if (this.selectedRole.permissions().includes(SharePermissions.deny)) {
@@ -212,19 +215,14 @@ export default {
     applyRoleAndPermissions() {
       if (this.existingRole) {
         this.selectedRole = this.existingRole
-      } else if (this.resourceIsSpace) {
-        this.selectedRole = SpacePeopleShareRoles.list(this.resource.canDeny())[0]
-      } else {
-        this.selectedRole = PeopleShareRoles.list(
-          this.resource.isFolder,
-          this.resource.canDeny()
-        )[0]
       }
 
-      if (this.selectedRole.hasCustomPermissions) {
-        this.customPermissions = this.existingPermissions
-      } else {
-        this.customPermissions = [...this.selectedRole.permissions(this.allowSharePermission)]
+      if (this.selectedRole) {
+        if (this.selectedRole.hasCustomPermissions) {
+          this.customPermissions = this.existingPermissions
+        } else {
+          this.customPermissions = [...this.selectedRole.permissions(this.allowSharePermission)]
+        }
       }
     },
 
@@ -246,7 +244,7 @@ export default {
     },
 
     isSelectedRole(role) {
-      return this.selectedRole.name === role.name
+      return this.selectedRole?.name === role.name
     },
 
     isPermissionDisabled(permission) {

--- a/packages/web-app-files/src/components/SideBar/Shares/SharesPanel.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/SharesPanel.vue
@@ -76,12 +76,14 @@ export default defineComponent({
           return
         }
         this.$nextTick(() => {
-          const [panelName, ref] = this.activePanel.split('#')
+          if (this.activePanel) {
+            const [panelName, ref] = this.activePanel.split('#')
 
-          if (!ref || !this.$refs[ref]) {
-            return
+            if (!ref || !this.$refs[ref]) {
+              return
+            }
+            this.$emit('scrollToElement', { element: this.$refs[ref].$el, panelName })
           }
-          this.$emit('scrollToElement', { element: this.$refs[ref].$el, panelName })
         })
       }
     },


### PR DESCRIPTION
This PR adresses JIRA Issue [CERNBOX-2862](https://its.cern.ch/jira/browse/CERNBOX-2862).

Before being able to create a share, users must now explicitly specify the permissions for it. A tooltip will guide the user on the missing details.

|Missing sharees|Missing role|Ready|
|--------------------|--------------|-----------|
|![image](https://user-images.githubusercontent.com/6058151/183625651-bb7980a5-86de-4783-b466-5c8d04d2c84f.png)|![image](https://user-images.githubusercontent.com/6058151/183625477-e72c3a9e-6e54-4a00-93a2-13d35c09a529.png)|![image](https://user-images.githubusercontent.com/6058151/183625530-6c142fe5-f312-4ef0-a7cb-b9071e31bdbb.png)|

Also, fixes an error showing up on the console when opening the details pane of a file because of a missing reference.