### PR TITLE
Disable most actions on home folder

### DIFF
--- a/packages/web-app-files/src/components/SideBar/Shares/FileLinks.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/FileLinks.vue
@@ -151,6 +151,7 @@ export default defineComponent({
   computed: {
     ...mapGetters('Files', ['highlightedFile', 'currentFileOutgoingLinks']),
     ...mapGetters(['capabilities', 'configuration']),
+    ...mapGetters(['homeFolder']),
     ...mapState(['user']),
     ...mapState('Files', ['sharesTree']),
 
@@ -169,6 +170,10 @@ export default defineComponent({
     },
     indirectCollapseButtonIcon() {
       return this.indirectLinkListCollapsed ? 'arrow-down-s' : 'arrow-up-s'
+    },
+
+    highlightedIsHomeFolder() {
+      return this.highlightedFile?.path === this.homeFolder
     },
 
     quicklink() {
@@ -252,6 +257,9 @@ export default defineComponent({
     },
 
     canCreatePublicLinks() {
+      if (this.highlightedIsHomeFolder) {
+        return false
+      }
       if (this.highlightedFile.isReceivedShare() && !this.hasResharing) {
         return false
       }
@@ -269,9 +277,13 @@ export default defineComponent({
     },
 
     noResharePermsMessage() {
-      const translatedFile = this.$gettext("You don't have permission to share this file.")
-      const translatedFolder = this.$gettext("You don't have permission to share this folder.")
-      return this.highlightedFile.type === 'file' ? translatedFile : translatedFolder
+      if (this.highlightedIsHomeFolder) {
+        return this.$gettext("You can't share your entire home folder")
+      } else if (this.highlightedFile.type === 'file') {
+        return this.$gettext("You don't have permission to share this file.")
+      } else if (this.highlightedFile.type === 'folder') {
+        return this.$gettext("You don't have permission to share this folder.")
+      }
     },
 
     linksHeading() {

--- a/packages/web-app-files/src/components/SideBar/Shares/FileShares.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/FileShares.vue
@@ -139,6 +139,7 @@ export default {
   },
   computed: {
     ...mapGetters('Files', ['highlightedFile', 'currentFileOutgoingCollaborators']),
+    ...mapGetters(['homeFolder']),
     ...mapState('Files', ['incomingShares', 'sharesTree']),
     ...mapState(['user']),
 
@@ -155,6 +156,10 @@ export default {
 
     hasSharees() {
       return this.collaborators.length > 0
+    },
+
+    highlightedIsHomeFolder() {
+      return this.highlightedFile?.path === this.homeFolder
     },
 
     /**
@@ -252,6 +257,9 @@ export default {
     },
 
     currentUserCanShare() {
+      if (this.highlightedIsHomeFolder) {
+        return false
+      }
       if (this.highlightedFile.isReceivedShare() && !this.hasResharing) {
         return false
       }
@@ -263,9 +271,13 @@ export default {
       return this.highlightedFile.canShare({ user: this.user })
     },
     noResharePermsMessage() {
-      const translatedFile = this.$gettext("You don't have permission to share this file.")
-      const translatedFolder = this.$gettext("You don't have permission to share this folder.")
-      return this.highlightedFile.type === 'file' ? translatedFile : translatedFolder
+      if (this.highlightedIsHomeFolder) {
+        return this.$gettext("You can't share your entire home folder")
+      } else if (this.highlightedFile.type === 'file') {
+        return this.$gettext("You don't have permission to share this file.")
+      } else if (this.highlightedFile.type === 'folder') {
+        return this.$gettext("You don't have permission to share this folder.")
+      }
     },
 
     currentUsersPermissions() {

--- a/packages/web-app-files/src/mixins/actions/copy.js
+++ b/packages/web-app-files/src/mixins/actions/copy.js
@@ -4,9 +4,11 @@ import {
   isLocationPublicActive,
   isLocationSpacesActive
 } from '../../router'
+import { mapGetters } from 'vuex'
 
 export default {
   computed: {
+    ...mapGetters(['homeFolder']),
     $_copy_items() {
       return [
         {
@@ -25,6 +27,9 @@ export default {
               return false
             }
             if (resources.length === 0) {
+              return false
+            }
+            if (resources[0].path === this.homeFolder) {
               return false
             }
 

--- a/packages/web-app-files/src/mixins/actions/delete.js
+++ b/packages/web-app-files/src/mixins/actions/delete.js
@@ -7,6 +7,7 @@ export default {
   computed: {
     ...mapState('Files', ['currentFolder']),
     ...mapGetters(['capabilities']),
+    ...mapGetters(['homeFolder']),
     $_delete_items() {
       return [
         {
@@ -28,7 +29,7 @@ export default {
             }
 
             const deleteDisabled = resources.some((resource) => {
-              return !resource.canBeDeleted()
+              return !resource.canBeDeleted() || resource.path === this.homeFolder
             })
             return !deleteDisabled
           },

--- a/packages/web-app-files/src/mixins/actions/downloadArchive.js
+++ b/packages/web-app-files/src/mixins/actions/downloadArchive.js
@@ -8,10 +8,12 @@ import isFilesAppActive from './helpers/isFilesAppActive'
 import path from 'path'
 import first from 'lodash-es/first'
 import { archiverService } from '../../services'
+import { mapGetters } from 'vuex'
 
 export default {
   mixins: [isFilesAppActive],
   computed: {
+    ...mapGetters(['homeFolder']),
     $_downloadArchive_items() {
       return [
         {
@@ -40,6 +42,9 @@ export default {
               return false
             }
             if (!archiverService.available) {
+              return false
+            }
+            if (resources[0].path === this.homeFolder) {
               return false
             }
             if (

--- a/packages/web-app-files/src/mixins/actions/downloadFile.js
+++ b/packages/web-app-files/src/mixins/actions/downloadFile.js
@@ -5,10 +5,12 @@ import {
   isLocationSpacesActive
 } from '../../router'
 import isFilesAppActive from './helpers/isFilesAppActive'
+import { mapGetters } from 'vuex'
 
 export default {
   mixins: [isFilesAppActive],
   computed: {
+    ...mapGetters(['homeFolder']),
     $_downloadFile_items() {
       return [
         {
@@ -34,6 +36,9 @@ export default {
               return false
             }
             if (resources[0].isFolder) {
+              return false
+            }
+            if (resources[0].path === this.homeFolder) {
               return false
             }
             return resources[0].canDownload()

--- a/packages/web-app-files/src/mixins/actions/move.js
+++ b/packages/web-app-files/src/mixins/actions/move.js
@@ -5,8 +5,10 @@ import {
   isLocationPublicActive,
   isLocationSpacesActive
 } from '../../router'
+import { mapGetters } from 'vuex'
 
 export default {
+  ...mapGetters(['homeFolder']),
   computed: {
     $_move_items() {
       return [
@@ -34,7 +36,7 @@ export default {
             }
 
             const moveDisabled = resources.some((resource) => {
-              return canBeMoved(resource, this.currentFolder.path) === false
+              return canBeMoved(resource, this.currentFolder.path) === false || resource.path === this.homeFolder
             })
             return !moveDisabled
           },

--- a/packages/web-app-files/src/mixins/actions/rename.js
+++ b/packages/web-app-files/src/mixins/actions/rename.js
@@ -13,6 +13,7 @@ export default {
   computed: {
     ...mapGetters('Files', ['files', 'currentFolder']),
     ...mapGetters(['capabilities']),
+    ...mapGetters(['homeFolder']),
     ...mapState('Files', ['areFileExtensionsShown']),
     ...mapGetters('runtime/auth', { isPublicLinkContext: 'isPublicLinkContextReady' }),
 
@@ -45,6 +46,9 @@ export default {
               return false
             }
             if (resources.length !== 1) {
+              return false
+            }
+            if (resources[0].path === this.homeFolder) {
               return false
             }
             // FIXME: once renaming shares in share_jail has been sorted out backend side we can enable renaming shares again

--- a/packages/web-app-files/src/quickActions.js
+++ b/packages/web-app-files/src/quickActions.js
@@ -11,6 +11,9 @@ export async function openSpaceMembersPanel(ctx) {
 
 export function canShare(item, store) {
   const { capabilities } = store.state.user
+  if (item.path === store.getters.homeFolder) {
+    return false
+  }
   if (!capabilities.files_sharing || !capabilities.files_sharing.api_enabled) {
     return false
   }


### PR DESCRIPTION
This PR disable most actions (share, link, move, rename, delete) on the user's home folder. Also shows a proper reason for which you cannot share your own home folder.

|Before|After|
|------|-----|
|![image](https://user-images.githubusercontent.com/6058151/184165573-01ca6543-6b91-4b9a-8212-0252a6d8510e.png)|![image](https://user-images.githubusercontent.com/6058151/184165951-bd9423bf-08e2-40de-a0f1-b652d5416719.png)|
