### PR TITLE
Fix quicklinks

### DIFF
--- a/packages/web-app-files/src/components/SideBar/Shares/FileLinks.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/FileLinks.vue
@@ -177,7 +177,9 @@ export default defineComponent({
     },
 
     quicklink() {
-      return this.currentFileOutgoingLinks.find((link) => link.quicklink === true)
+      return this.currentFileOutgoingLinks.find(
+        (link) => link.quicklink || link.name === '__quicklink' || link.name === 'Quicklink'
+      )
     },
 
     share() {
@@ -300,7 +302,9 @@ export default defineComponent({
 
     links() {
       return this.currentFileOutgoingLinks
-        .filter((link) => !link.quicklink)
+        .filter((link) => {
+          return !(link.quicklink || link.name === '__quicklink' || link.name === 'Quicklink')
+        })
         .map((share) => {
           share.key = 'direct-link-' + share.id
           return share

--- a/packages/web-app-files/src/components/SideBar/Shares/Links/CreateQuickLink.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/Links/CreateQuickLink.vue
@@ -45,7 +45,7 @@ export default {
     createQuickLink() {
       this.$emit('createPublicLink', {
         link: {
-          name: this.$gettext('Quicklink'),
+          name: '__quicklink',
           permissions: 1,
           expiration: this.expirationDate.enforced ? this.expirationDate.default : null,
           quicklink: true,

--- a/packages/web-app-files/src/components/SideBar/Shares/Links/NameAndCopy.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/Links/NameAndCopy.vue
@@ -44,6 +44,9 @@ export default {
   }),
   computed: {
     linkName() {
+      if (this.link.name === '__quicklink') {
+        return 'Quicklink'
+      }
       return this.link.name
     },
     copyBtnLabel() {

--- a/packages/web-app-files/src/helpers/share/link.ts
+++ b/packages/web-app-files/src/helpers/share/link.ts
@@ -17,7 +17,7 @@ interface CreateQuicklink {
 
 export const createQuicklink = async (args: CreateQuicklink): Promise<Share> => {
   const params: { [key: string]: unknown } = {
-    name: $gettext('Quicklink'),
+    name: '__quicklink',
     permissions: 1,
     quicklink: true
   }


### PR DESCRIPTION
Quicklinks are not working for multiple reasons:

* The 'copy quicklink' quick action button does not check if a quick link already exists, so it always creates a new one
* The backend does not store if a link is quick or not (https://its.cern.ch/jira/browse/CERNBOX-2749)

This PR fixes those problems. The second one is a workaround in the frontend to use the link name property to determine if a link is quick. This can be easily reverted once the proper data is saved in the backend, and will work when that happens too. Also, the name property is not being used at the moment except to show if a link is normal or quick, so it makes sense to use it.

An added benefit is any previously created quicklink will now be displayed properly too. Users who created a lot of quicklinks will still get a cleaner link list, because only one of them will show in the proper slot and the rest will be hidden (and appear there one by one if the first is deleted).

|Before|After|
|------|-----|
|![image](https://user-images.githubusercontent.com/6058151/184324516-d5b4bfe6-72ba-4865-a491-5b9474ed302d.png)|![image](https://user-images.githubusercontent.com/6058151/184325657-b5dfd289-8f71-495d-ad1b-f34d198de462.png)|