### PR TITLE
Do not load requirejs from CDN

### DIFF
--- a/packages/web-container/index.html.ejs
+++ b/packages/web-container/index.html.ejs
@@ -9,12 +9,7 @@
   <% Object.keys(data.bundle.css).forEach((s) => { %>
     <link href="<%= data.config.baseUrl %><%- data.bundle.css[s] %>?<%= data.compilationTimestamp %>" rel="stylesheet">
   <% }); %>
-  <% if (data.config.cdn) { %>
-  <script src="//cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js"></script>
-  <script>if (typeof requirejs === 'undefined') { document.write('<script src="js/require.js?<%= data.compilationTimestamp %>">\x3C/script>') }</script>
-  <% } else { %>
   <script src="<%= data.config.baseUrl %>js/require.js?<%= data.compilationTimestamp %>"></script>
-  <% } %>
   <style>
     html,
     body {
@@ -78,8 +73,7 @@
     } else {
       requirejs.config({
         baseUrl: <%- JSON.stringify(data.roots.js) %>,
-        paths: <%- JSON.stringify(data.bundle.js) %>,
-        ...<%- JSON.stringify(data.config.requirejs) %>
+        paths: <%- JSON.stringify(data.bundle.js) %>
       })
 
       requirejs(['web-runtime'], function (runtime) {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -28,8 +28,6 @@ const { version } = require('./package.json')
 const compilationTimestamp = new Date().getTime()
 
 const config = {
-  requirejs: {},
-  cdn: process.env.CDN === 'true',
   baseUrl: process.env.BASE_URL || '/',
   history_mode: process.env.HISTORY_MODE === 'true'
 }
@@ -158,8 +156,8 @@ const plugins = [
                 css: config.baseUrl + 'css',
                 js: config.baseUrl + 'js'
               },
-              config: config,
-              compilationTimestamp: compilationTimestamp
+              config,
+              compilationTimestamp
             }
           },
           {},
@@ -229,7 +227,7 @@ export default {
   output: {
     dir: 'dist',
     format: 'amd',
-    sourcemap: sourcemap,
+    sourcemap,
     chunkFileNames: path.join('js', 'chunks', production ? '[name]-[hash].js' : '[name].js'),
     entryFileNames: path.join('js', production ? '[name]-[hash].js' : '[name].js')
   },


### PR DESCRIPTION
This PR removes the initial attempt to load RequireJS from a CloudFlare. Security team requested it to avoid supply chain attacks, and also some users were explicitly blocking cloudflare and had problems loading the web.