### PR TITLE
Switch back to upstream owncloud-sdk

### DIFF
--- a/packages/web-runtime/package.json
+++ b/packages/web-runtime/package.json
@@ -25,7 +25,7 @@
     "luxon": "^2.4.0",
     "marked": "^4.0.12",
     "oidc-client-ts": "^2.1.0",
-    "owncloud-sdk": "github:cernbox/owncloud-sdk#notifications",
+    "owncloud-sdk": "~3.1.0-alpha.5",
     "p-queue": "^6.6.2",
     "portal-vue": "3.0.0",
     "postcss-import": "^12.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -660,7 +660,7 @@ importers:
       luxon: ^2.4.0
       marked: ^4.0.12
       oidc-client-ts: ^2.1.0
-      owncloud-sdk: github:cernbox/owncloud-sdk#notifications
+      owncloud-sdk: ~3.1.0-alpha.5
       p-queue: ^6.6.2
       portal-vue: 3.0.0
       postcss-import: ^12.0.1
@@ -708,7 +708,7 @@ importers:
       luxon: 2.4.0
       marked: 4.0.12
       oidc-client-ts: 2.1.0
-      owncloud-sdk: github.com/cernbox/owncloud-sdk/7a9a3ecbf23ab9d8e538baa61dc47b75d084a189_qgpf6seimtkgc6dfu7oqfstxh4
+      owncloud-sdk: 3.1.0-alpha.5_qgpf6seimtkgc6dfu7oqfstxh4
       p-queue: 6.6.2
       portal-vue: 3.0.0_vue@3.2.45
       postcss-import: 12.0.1
@@ -17544,8 +17544,8 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
-  /owncloud-sdk/3.1.0-alpha.3_qgpf6seimtkgc6dfu7oqfstxh4:
-    resolution: {integrity: sha512-jouNHVHUJBuYs7A1ZPUNl+uSUulSYwTFzOjW4NhONl9xbDthKDeB+vWycUY9IdFRKroF8l1qo4xkXVO9mn7U/A==}
+  /owncloud-sdk/3.1.0-alpha.5_qgpf6seimtkgc6dfu7oqfstxh4:
+    resolution: {integrity: sha512-My5jQSCVp9FwI7dtCTFcFLiVSfNl22s8/xCki6OsyZulFoeWB2LGzlYBQFAFKGPeIsExQascDHBM8kj/fF4z6A==}
     peerDependencies:
       axios: ^0.27.2
       cross-fetch: ^3.0.6
@@ -23365,31 +23365,6 @@ packages:
       pug: 3.0.2
     transitivePeerDependencies:
       - supports-color
-    dev: false
-
-  github.com/cernbox/owncloud-sdk/7a9a3ecbf23ab9d8e538baa61dc47b75d084a189_qgpf6seimtkgc6dfu7oqfstxh4:
-    resolution: {tarball: https://codeload.github.com/cernbox/owncloud-sdk/tar.gz/7a9a3ecbf23ab9d8e538baa61dc47b75d084a189}
-    id: github.com/cernbox/owncloud-sdk/7a9a3ecbf23ab9d8e538baa61dc47b75d084a189
-    name: owncloud-sdk
-    version: 3.0.0
-    peerDependencies:
-      axios: ^0.27.2
-      cross-fetch: ^3.0.6
-      promise: ^8.1.0
-      qs: ^6.10.3
-      utf8: ^3.0.0
-      uuid: ^8.2.0
-      webdav: 4.10.0
-      xml-js: ^1.6.11
-    dependencies:
-      axios: 0.27.2
-      cross-fetch: 3.1.4
-      promise: 8.1.0
-      qs: 6.10.3
-      utf8: 3.0.0
-      uuid: 9.0.0
-      webdav: 4.10.0
-      xml-js: 1.6.11
     dev: false
 
   github.com/dschmidt/v-calendar/3ce6e3b8afd5491cb53ee811281d5fa8a45b044d_vue@3.2.45:


### PR DESCRIPTION
We can switch back as the [notifications changes](https://github.com/owncloud/owncloud-sdk/releases/tag/v3.1.0-alpha.5) have been merged upstream really fast! :tada: