### PR TITLE
Ceph fixes

### DIFF
--- a/packages/web-app-files/src/index.ts
+++ b/packages/web-app-files/src/index.ts
@@ -84,9 +84,9 @@ const navItems = [
     name: $gettext('Win spaces'),
     icon: 'layout-grid',
     route: {
-      path: `/${appInfo.id}/spaces/cephfs`
+      path: `/${appInfo.id}/spaces/winspaces`
     },
-    activeFor: [{ path: `/${appInfo.id}/spaces/cephfs` }],
+    activeFor: [{ path: `/${appInfo.id}/spaces/winspaces` }],
     enabled(capabilities) {
       return capabilities.group_based?.capabilities?.includes('cephfs-mount') || false
     }

--- a/packages/web-app-files/src/index.ts
+++ b/packages/web-app-files/src/index.ts
@@ -70,7 +70,7 @@ const navItems = [
     }
   },
   {
-    name: $gettext('Projects'),
+    name: $gettext('EOS projects'),
     icon: 'layout-grid',
     route: {
       path: `/${appInfo.id}/spaces/projects`
@@ -78,6 +78,17 @@ const navItems = [
     activeFor: [{ path: `/${appInfo.id}/spaces/project` }],
     enabled(capabilities) {
       return capabilities.spaces && capabilities.spaces.projects === true
+    }
+  },
+  {
+    name: $gettext('Win spaces'),
+    icon: 'layout-grid',
+    route: {
+      path: `/${appInfo.id}/spaces/cephfs`
+    },
+    activeFor: [{ path: `/${appInfo.id}/spaces/cephfs` }],
+    enabled(capabilities) {
+      return capabilities.group_based?.capabilities?.includes('cephfs-mount') || false
     }
   },
   {
@@ -103,17 +114,6 @@ const navItems = [
     separate: true,
     enabled(capabilities) {
       return true
-    }
-  },
-  {
-    name: $gettext('HPC Data'),
-    icon: 'folder',
-    route: {
-      path: `/${appInfo.id}/spaces/cephfs`
-    },
-    separate: true,
-    enabled(capabilities) {
-      return capabilities.group_based?.capabilities?.includes('cephfs-mount') || false
     }
   }
 ]

--- a/packages/web-pkg/src/composables/driveResolver/useDriveResolver.ts
+++ b/packages/web-pkg/src/composables/driveResolver/useDriveResolver.ts
@@ -95,7 +95,7 @@ export const useDriveResolver = (options: DriveResolverOptions = {}): DriveResol
         }
         if (matchingSpace) {
           path = driveAliasAndItem.slice(matchingSpace.driveAlias.length)
-        } else if (driveAliasAndItem.startsWith('eos') || driveAliasAndItem.startsWith('cephfs')) {
+        } else if (driveAliasAndItem.startsWith('eos') || driveAliasAndItem.startsWith('winspaces')) {
           matchingSpace = unref(spaces).find((s) => s.driveType === 'personal')
           path = driveAliasAndItem
         }

--- a/packages/web-pkg/src/composables/driveResolver/useDriveResolver.ts
+++ b/packages/web-pkg/src/composables/driveResolver/useDriveResolver.ts
@@ -95,7 +95,7 @@ export const useDriveResolver = (options: DriveResolverOptions = {}): DriveResol
         }
         if (matchingSpace) {
           path = driveAliasAndItem.slice(matchingSpace.driveAlias.length)
-        } else if (driveAliasAndItem.startsWith('eos')) {
+        } else if (driveAliasAndItem.startsWith('eos') || driveAliasAndItem.startsWith('cephfs')) {
           matchingSpace = unref(spaces).find((s) => s.driveType === 'personal')
           path = driveAliasAndItem
         }


### PR DESCRIPTION
This PR fixes the routing for Ceph paths (`/cephfs/*`) and reorders the sidebar a bit.

![image](https://github.com/cernbox/web/assets/6058151/115e198c-206f-4f2c-a1c2-b20720a2d7cb)
