### PR TITLE
fix: remove undefined links

### DIFF
--- a/packages/web-app-files/src/components/SideBar/Details/FileDetails.vue
+++ b/packages/web-app-files/src/components/SideBar/Details/FileDetails.vue
@@ -141,7 +141,7 @@
             </div>
           </td>
         </tr>
-        <tr v-if="runningOnEos">
+        <tr v-if="runningOnEos && !!directLink">
           <th scope="col" class="oc-pr-s" v-text="directLinkLabel" />
           <td>
             <div class="oc-flex oc-flex-middle oc-flex-between oc-width-1-1">
@@ -239,7 +239,9 @@ export default defineComponent({
     const directLink = computed(() => {
       return !unref(isPublicLinkContext)
         ? `${store.getters.configuration.server}files/spaces${encodePath(unref(resource).path)}`
-        : `${store.getters.configuration.server.replace(/\/+$/, '')}${unref(resource).downloadURL}`
+        : unref(resource).downloadURL
+          ? `${store.getters.configuration.server.replace(/\/+$/, '')}${unref(resource).downloadURL}`
+          : ''
     })
 
     const copyEosPathToClipboard = () => {

--- a/packages/web-runtime/src/services/auth/authService.ts
+++ b/packages/web-runtime/src/services/auth/authService.ts
@@ -26,7 +26,7 @@ export class AuthService {
     configurationManager: ConfigurationManager,
     clientService: ClientService,
     store: Store<any>,
-    router: Router,
+    router: Router
   ): void {
     this.configurationManager = configurationManager
     this.clientService = clientService
@@ -60,6 +60,10 @@ export class AuthService {
       if (publicLinkToken) {
         await this.publicLinkManager.updateContext(publicLinkToken)
       }
+    } else {
+      if (this.store.getters['runtime/auth/isPublicLinkContextReady']) {
+        await this.publicLinkManager.clear(extractPublicLinkToken(to))
+      }
     }
 
     if (!this.userManager) {
@@ -71,7 +75,6 @@ export class AuthService {
     }
 
     if (!isAnonymousContext(this.router, to)) {
-
       if (!this.userManager.areEventHandlersRegistered) {
         this.userManager.events.addAccessTokenExpired((...args): void => {
           const handleExpirationError = () => {


### PR DESCRIPTION
- removes the Direct Links  in case of undefined link (`cernbox.chundefined`)
- reset `isPublicLinkContext` without the need to refresh the page