### PR TITLE
fix: default sorting in office files view

### DIFF
--- a/packages/web-app-files/src/views/OfficeFiles.vue
+++ b/packages/web-app-files/src/views/OfficeFiles.vue
@@ -135,6 +135,11 @@ export default defineComponent({
       })
     }
 
+    if (!localStorage.getItem('oc_options_files-common-office_sort-by')) {
+      localStorage.setItem('oc_options_files-common-office_sort-by', 'mdate')
+      localStorage.setItem('oc_options_files-common-office_sort-dir', 'desc')
+    }
+
     return {
       ...useResourcesViewDefaults<Resource, any, any[]>(),
       getSpace


### PR DESCRIPTION
if not defined, office files view is sorted by 'Modified' dates