### PR TITLE
fix: copy button visibility

### DIFF
--- a/packages/web-pkg/src/composables/actions/files/useFileActionsCopy.ts
+++ b/packages/web-pkg/src/composables/actions/files/useFileActionsCopy.ts
@@ -76,14 +76,6 @@ export const useFileActionsCopy = () => {
             return false
           }
 
-          if (unref(configStore.options.runningOnEos)) {
-            // CERNBox does not allow actions above home/project root
-            const elems = resources[0].path?.split('/').filter(Boolean) || [] //"/eos/project/c/cernbox"
-            if (isLocationSpacesActive(router, 'files-spaces-generic') && elems.length < 5) {
-              return false
-            }
-          }
-
           if (!unref(resources)[0].canDownload()) {
             return false
           }


### PR DESCRIPTION
Adds "Copy" button back to actions for files with a path level lower than 5.
Paths are now relative, the condition became outdated
