### PR TITLE
fix: open default editor for file public links

### DIFF
--- a/packages/web-app-files/src/views/spaces/GenericSpace.vue
+++ b/packages/web-app-files/src/views/spaces/GenericSpace.vue
@@ -614,10 +614,7 @@ export default defineComponent({
       }
 
       if (this.configOptions.runningOnEos) {
-        if (
-          !this.currentFolder.fileId ||
-          this.currentFolder.path === this.paginatedResources[0].path
-        ) {
+        if (!this.currentFolder.fileId || this.currentFolder.id === this.paginatedResources[0].id) {
           return true
         }
       }


### PR DESCRIPTION
display as a single resource if:
- has only one resource and it is not a folder
- the current folder id is the same as the resource (when running on EOS)