### PR TITLE
feat: add config for footer versions

### DIFF
--- a/packages/web-pkg/src/composables/piniaStores/config/config.ts
+++ b/packages/web-pkg/src/composables/piniaStores/config/config.ts
@@ -34,6 +34,7 @@ const defaultOptions = {
     idBased: true,
     fullShareOwnerPaths: false
   },
+  listVersions: true,
   runningOnEos: false,
   tokenStorageLocal: true,
   userListRequiresFilter: false,

--- a/packages/web-pkg/src/composables/piniaStores/config/types.ts
+++ b/packages/web-pkg/src/composables/piniaStores/config/types.ts
@@ -127,6 +127,7 @@ const OptionsConfigSchema = z.object({
   hideAccountMenu: z.boolean().optional(),
   hideNavigation: z.boolean().optional(),
   defaultLanguage: z.string().optional(),
+  listVersions: z.boolean().optional(),
   alertRwFolders: z.record(z.string()).optional()
 })
 

--- a/packages/web-runtime/src/components/SidebarNav/SidebarNav.vue
+++ b/packages/web-runtime/src/components/SidebarNav/SidebarNav.vue
@@ -45,7 +45,10 @@
     </nav>
     <!-- @slot bottom content of the sidebar -->
     <slot name="bottom">
-      <div v-if="!closed" class="versions oc-pb-m oc-pl-m oc-text-xsmall oc-text-muted">
+      <div
+        v-if="!closed && listVersions"
+        class="versions oc-pb-m oc-pl-m oc-text-xsmall oc-text-muted"
+      >
         <span v-text="backendVersion" />
         <span v-text="webVersion" />
       </div>
@@ -69,7 +72,7 @@ import { v4 as uuidV4 } from 'uuid'
 import SidebarNavItem from './SidebarNavItem.vue'
 import { NavItem } from '../../helpers/navItems'
 import { getBackendVersion, getWebVersion } from '../../container/versions'
-import { useCapabilityStore } from '@ownclouders/web-pkg'
+import { useCapabilityStore, useConfigStore } from '@ownclouders/web-pkg'
 
 type NavItemRef = InstanceType<typeof SidebarNavItem>
 
@@ -89,8 +92,10 @@ export default defineComponent({
     let resizeObserver: ResizeObserver
     const navItemRefs = ref<Record<string, NavItemRef>>({})
     const highlighterAttrs = ref<Record<string, unknown>>({})
+    const configStore = useConfigStore()
     const capabilityStore = useCapabilityStore()
 
+    const listVersions = unref(configStore.options).listVersions
     const webVersion = computed(() => getWebVersion())
     const backendVersion = computed(() => getBackendVersion({ capabilityStore }))
 
@@ -140,7 +145,7 @@ export default defineComponent({
       { deep: true, immediate: true }
     )
 
-    return { highlighterAttrs, navItemRefs, backendVersion, webVersion }
+    return { highlighterAttrs, navItemRefs, backendVersion, webVersion, listVersions }
   },
   computed: {
     toggleSidebarButtonClass() {


### PR DESCRIPTION
- reva and web ui versions not listed by default
- new configStore property to define this behavior