### PR TITLE
fix: path based space requests

### DIFF
--- a/packages/web-app-files/src/composables/actions/spaces/useSpaceActionsUploadImage.ts
+++ b/packages/web-app-files/src/composables/actions/spaces/useSpaceActionsUploadImage.ts
@@ -1,5 +1,5 @@
 import { computed, unref, VNodeRef } from 'vue'
-import { SpaceResource } from '@ownclouders/web-client'
+import { SpaceResource, urlJoin } from '@ownclouders/web-client'
 import {
   useClientService,
   useLoadingService,
@@ -8,7 +8,8 @@ import {
   useMessages,
   useSpacesStore,
   useSpaceHelpers,
-  useSharesStore
+  useSharesStore,
+  useConfigStore
 } from '@ownclouders/web-pkg'
 import { eventBus } from '@ownclouders/web-pkg'
 import { useGettext } from 'vue3-gettext'
@@ -24,8 +25,11 @@ export const useSpaceActionsUploadImage = ({ spaceImageInput }: { spaceImageInpu
   const previewService = usePreviewService()
   const spacesStore = useSpacesStore()
   const sharesStore = useSharesStore()
+  const configStore = useConfigStore()
   const { createDefaultMetaFolder } = useCreateSpace()
   const { getDefaultMetaFolder } = useSpaceHelpers()
+
+  const configOptions = configStore.options
 
   let selectedSpace: SpaceResource = null
   const handler = ({ resources }: SpaceActionOptions) => {
@@ -72,6 +76,7 @@ export const useSpaceActionsUploadImage = ({ spaceImageInput }: { spaceImageInpu
         const { fileId } = await clientService.webdav.putFileContents(selectedSpace, {
           parentFolderId: metaFolder.id,
           fileName: file.name,
+          path: !configOptions.routing.idBased ? urlJoin(metaFolder.path, file.name) : undefined,
           content,
           headers,
           overwrite: true

--- a/packages/web-client/src/helpers/space/functions.ts
+++ b/packages/web-client/src/helpers/space/functions.ts
@@ -34,14 +34,18 @@ export function buildWebDavSpacesTrashPath(storageId: string, path = '') {
   })
 }
 
-export function getRelativeSpecialFolderSpacePath(space: SpaceResource, type: 'image' | 'readme') {
+export function getRelativeSpecialFolderSpacePath(
+  space: SpaceResource,
+  type: 'image' | 'readme',
+  spaceID: string
+) {
   const typeMap = { image: 'spaceImageData', readme: 'spaceReadmeData' } as const
   const specialProp = space[typeMap[type]]
   if (!specialProp) {
     return ''
   }
   const webDavPathComponents = decodeURI(specialProp.webDavUrl).split('/')
-  const idComponent = webDavPathComponents.find((c) => c.startsWith(space.id))
+  const idComponent = webDavPathComponents.find((c) => c.startsWith(spaceID))
   if (!idComponent) {
     return ''
   }

--- a/packages/web-pkg/src/composables/actions/spaces/useSpaceActionsEditReadmeContent.ts
+++ b/packages/web-pkg/src/composables/actions/spaces/useSpaceActionsEditReadmeContent.ts
@@ -5,7 +5,7 @@ import { useGettext } from 'vue3-gettext'
 import { useOpenWithDefaultApp } from '../useOpenWithDefaultApp'
 import { getRelativeSpecialFolderSpacePath, Resource, SpaceResource } from '@ownclouders/web-client'
 import { useClientService } from '../../clientService'
-import { useSharesStore, useSpacesStore, useUserStore } from '../../piniaStores'
+import { useConfigStore, useSharesStore, useSpacesStore, useUserStore } from '../../piniaStores'
 import { useCreateSpace, useSpaceHelpers } from '../../spaces'
 
 export const useSpaceActionsEditReadmeContent = () => {
@@ -15,8 +15,11 @@ export const useSpaceActionsEditReadmeContent = () => {
   const userStore = useUserStore()
   const spacesStore = useSpacesStore()
   const sharesStore = useSharesStore()
+  const configStore = useConfigStore()
   const { $gettext } = useGettext()
   const { getDefaultMetaFolder } = useSpaceHelpers()
+
+  const configOptions = configStore.options
 
   const createReadme = async (space: SpaceResource, metaFolder: Resource) => {
     // FIXME: remove path as soon as we make the full switch to id-based dav requests
@@ -54,7 +57,8 @@ export const useSpaceActionsEditReadmeContent = () => {
     }
 
     if (!markdownResource) {
-      const path = getRelativeSpecialFolderSpacePath(resources[0], 'readme')
+      const spaceID = configOptions.routing.idBased ? resources[0].id : resources[0].name
+      const path = getRelativeSpecialFolderSpacePath(resources[0], 'readme', spaceID)
       if (path) {
         markdownResource = await clientService.webdav.getFileInfo(resources[0], { path })
       } else {

--- a/packages/web-pkg/src/composables/actions/spaces/useSpaceActionsSetIcon.ts
+++ b/packages/web-pkg/src/composables/actions/spaces/useSpaceActionsSetIcon.ts
@@ -1,10 +1,11 @@
-import { SpaceResource } from '@ownclouders/web-client'
+import { SpaceResource, urlJoin } from '@ownclouders/web-client'
 import { computed } from 'vue'
 import { SpaceAction, SpaceActionOptions } from '../types'
 import { useClientService } from '../../clientService'
 import { useLoadingService } from '../../loadingService'
 import { useGettext } from 'vue3-gettext'
 import {
+  useConfigStore,
   useMessages,
   useModals,
   useSharesStore,
@@ -23,10 +24,13 @@ export const useSpaceActionsSetIcon = () => {
   const clientService = useClientService()
   const loadingService = useLoadingService()
   const spacesStore = useSpacesStore()
+  const configStore = useConfigStore()
   const { createDefaultMetaFolder } = useCreateSpace()
   const { dispatchModal } = useModals()
   const { getDefaultMetaFolder } = useSpaceHelpers()
   const sharesStore = useSharesStore()
+
+  const configOptions = configStore.options
 
   const handler = ({ resources }: SpaceActionOptions) => {
     if (resources.length !== 1) {
@@ -86,6 +90,7 @@ export const useSpaceActionsSetIcon = () => {
         const { fileId } = await clientService.webdav.putFileContents(space, {
           parentFolderId: metaFolder.id,
           fileName: 'emoji.png',
+          path: !configOptions.routing.idBased ? urlJoin(metaFolder.path, 'emoji.png') : undefined,
           content,
           headers,
           overwrite: true


### PR DESCRIPTION
- fixes editing a space's README file.
- checks if the idBased is true before sending the request (for image/icon upload)

if needed, it can be done with the rest of the spaces actions for the sake of keeping the same behavior (even though we don't support those in CERNBox)