### PR TITLE
fix: spaces sorting

### DIFF
--- a/packages/web-app-files/src/views/spaces/Projects.vue
+++ b/packages/web-app-files/src/views/spaces/Projects.vue
@@ -332,7 +332,12 @@ export default defineComponent({
     const items = computed(() =>
       orderBy(
         filter(unref(spaces), unref(filterTerm)),
-        [(item: SpaceResource) => item[unref(sortBy)].toLowerCase()],
+        [
+          (item: SpaceResource) =>
+            typeof item[unref(sortBy)] === 'string'
+              ? item[unref(sortBy)].toLowerCase()
+              : item[unref(sortBy)]
+        ],
         unref(sortDir)
       )
     )


### PR DESCRIPTION
This PR checks the type of the properties before using `.toLowerCase()` function, which caused crashes with the number values.

upstream/original commit: https://github.com/owncloud/web/commit/3f92feb319061086ca3e523af0e8535c283e3a5e