### PR TITLE
Fix Group search

### DIFF
--- a/packages/web-app-files/src/components/SideBar/Shares/Collaborators/InviteCollaborator/AutocompleteItem.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/Collaborators/InviteCollaborator/AutocompleteItem.vue
@@ -61,7 +61,10 @@ export default {
       if (props.item.onPremisesSamAccountName) {
         return `${props.item.onPremisesSamAccountName} - ${props.item.mail}`
       }
-      return props.item.mail
+      return (
+        props.item.mail ||
+        (props.item.id.toLowerCase() === props.item.displayName?.toLowerCase() ? '' : props.item.id)
+      )
     })
 
     const externalIssuer = computed(() => {

--- a/packages/web-app-files/src/components/SideBar/Shares/Collaborators/InviteCollaborator/InviteCollaboratorForm.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/Collaborators/InviteCollaborator/InviteCollaboratorForm.vue
@@ -606,6 +606,7 @@ export default defineComponent({
         (recipient) =>
           recipient.shareType === ShareTypes.remote.value ||
           recipient.displayName.toLocaleLowerCase().indexOf(query.toLocaleLowerCase()) > -1 ||
+          recipient.id.toLocaleLowerCase().indexOf(query.toLocaleLowerCase()) > -1 ||
           recipient.onPremisesSamAccountName
             ?.toLocaleLowerCase()
             .indexOf(query.toLocaleLowerCase()) > -1 ||


### PR DESCRIPTION
If a user friendly display name is set, we were not including because we only checked that and not the id. Show both display name and id when listing, if the name and id are different (otherwise we have many repeated lines with the same text).
