### PR TITLE
fix: preview correct shared image

### DIFF
--- a/packages/web-app-preview/src/App.vue
+++ b/packages/web-app-preview/src/App.vue
@@ -94,7 +94,8 @@ import {
   useRoute,
   useRouteQuery,
   useRouter,
-  usePreviewService
+  usePreviewService,
+  useConfigStore
 } from '@ownclouders/web-pkg'
 import MediaControls from './components/MediaControls.vue'
 import MediaAudio from './components/Sources/MediaAudio.vue'
@@ -141,6 +142,7 @@ export default defineComponent({
     const contextRouteQuery = useRouteQuery('contextRouteQuery') as unknown as Ref<
       Record<string, string>
     >
+    const configStore = useConfigStore()
 
     const { isFileTypeAudio, isFileTypeImage, isFileTypeVideo } = useFileTypes()
     const previewService = usePreviewService()
@@ -316,7 +318,8 @@ export default defineComponent({
       isAutoPlayEnabled,
       preview,
       isFileTypeImage,
-      loadFileIntoCache
+      loadFileIntoCache,
+      configStore
     }
   },
 
@@ -352,7 +355,10 @@ export default defineComponent({
   methods: {
     setActiveFile(driveAliasAndItem: string) {
       for (let i = 0; i < this.filteredFiles.length; i++) {
-        if (isShareSpaceResource(unref(this.currentFileContext.space))) {
+        if (
+          !this.configStore.options.routing.fullShareOwnerPaths &&
+          isShareSpaceResource(unref(this.currentFileContext.space))
+        ) {
           // with share space resources, we don't have an underlying space, so match the file id
           if (this.filteredFiles[i].remoteItemId === this.fileId) {
             this.activeIndex = i


### PR DESCRIPTION
```
if (this.filteredFiles[i].remoteItemId === this.fileId) {
...
```
both values are undefined when opening an image inside a shared folder.
which means: the first check is always true and the first resource would be displayed instead of the selected one.

removing the extra conditions for shared resources works just fine.