### PR TITLE
feat: add UI feedback for version restoring

### DIFF
--- a/packages/web-app-files/src/components/SideBar/Versions/FileVersions.vue
+++ b/packages/web-app-files/src/components/SideBar/Versions/FileVersions.vue
@@ -60,7 +60,8 @@ import {
   formatFileSize,
   useClientService,
   useDownloadFile,
-  useResourcesStore
+  useResourcesStore,
+  useMessages
 } from '@ownclouders/web-pkg'
 import { computed, defineComponent, inject, Ref, unref } from 'vue'
 import { isShareSpaceResource, Resource, SpaceResource } from '@ownclouders/web-client'
@@ -78,8 +79,10 @@ export default defineComponent({
   setup(props) {
     const clientService = useClientService()
     const language = useGettext()
+    const { $gettext } = language
     const { downloadFile } = useDownloadFile({ clientService })
     const { updateResourceField } = useResourcesStore()
+    const { showMessage, showErrorMessage } = useMessages()
 
     const space = inject<Ref<SpaceResource>>('space')
     const resource = inject<Ref<Resource>>('resource')
@@ -100,7 +103,15 @@ export default defineComponent({
     })
 
     const revertToVersion = async (version: Resource) => {
-      await clientService.webdav.restoreFileVersion(unref(space), unref(resource), version.name)
+      try {
+        await clientService.webdav.restoreFileVersion(unref(space), unref(resource), version.name)
+        showMessage({ title: $gettext('Version was successfully restored') })
+      } catch (error) {
+        showErrorMessage({
+          title: $gettext('Error restoring file version'),
+          errors: [error]
+        })
+      }
       const restoredResource = await clientService.webdav.getFileInfo(unref(space), unref(resource))
 
       const fieldsToUpdate = ['size', 'mdate'] as const


### PR DESCRIPTION
at this moment, because of the EOS response in Reva, the request would always be successful, and the feedback message would always be positive.

considering that the files listed are always valid versions, it's not expected for this request to fail in the EOS level.
and, with this try-catch block, the code would already be prepared for a moment when the failed response is fixed. 