### PR TITLE
fix: remove option to edit a share with yourself

### DIFF
--- a/packages/web-app-files/src/components/SideBar/Shares/FileShares.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/FileShares.vue
@@ -428,6 +428,11 @@ export default defineComponent({
         return false
       }
 
+      // users should not be able to add/edit themselves
+      if (collaborator.sharedWith.id === this.user.id) {
+        return false
+      }
+
       if (isProjectSpaceResource(this.space) || isShareSpaceResource(this.space)) {
         return this.space.canShare({ user: this.user })
       }


### PR DESCRIPTION
It's a workaround to be consistent with filtering out the current user when searching for a share

To be reverted once there is a more complete fix in Reva.