### PR TITLE
feat: get hasEditor from appInfo

### DIFF
--- a/packages/web-runtime/src/container/application/classic.ts
+++ b/packages/web-runtime/src/container/application/classic.ts
@@ -111,7 +111,10 @@ export const convertClassicApplication = ({
 
   const appsStore = useAppsStore()
   appsStore.registerApp(
-    { ...applicationScript.appInfo, hasEditor: applicationScript.routes?.length > 0 },
+    {
+      ...applicationScript.appInfo,
+      hasEditor: applicationScript.appInfo['hasEditor'] ?? applicationScript.routes?.length > 0
+    },
     applicationScript.translations
   )
 


### PR DESCRIPTION
The editor actions defined in the context menu are filtered by `hasEditor` property ( https://github.com/cernbox/web/commit/79c8c55390d123eb6898c23de8045bd82d99946b ).
But because of https://github.com/cernbox/web/commit/487e54ecb31913c85770f53e032186d9fefc37de , this property is set based on the number of routes registered in the app.

This PR fixes this behavior by reading from `appInfo` first and then, only if undefined, using the number of routes as a fallback.