### PR TITLE
fix: links for files with special characters

### DIFF
--- a/packages/web-pkg/src/components/FilesList/ResourceTable.vue
+++ b/packages/web-pkg/src/components/FilesList/ResourceTable.vue
@@ -260,6 +260,7 @@ import {
 } from 'vue'
 import { useWindowSize } from '@vueuse/core'
 import {
+  encodePath,
   IncomingShareResource,
   isPasswordProtectedFolderFileResource,
   isProjectSpaceResource,
@@ -646,7 +647,7 @@ export default defineComponent({
         return
       }
 
-      return action.route({ space, resources: [resource] })
+      return action.route({ space, resources: [{ ...resource, path: encodePath(resource.path) }] })
     }
 
     const isResourceInDeleteQueue = (id: string): boolean => {


### PR DESCRIPTION
path encoding for opening files named with special characters (i.e, `#`)