### PR TITLE
fix: change event to check a success in ms-apps

### DIFF
--- a/packages/web-app-external/src/App.vue
+++ b/packages/web-app-external/src/App.vue
@@ -127,7 +127,7 @@ export default defineComponent({
 
     const removeAlertOnSuccessfulLoad = (event: MessageEvent) => {
       const data = JSON.parse(event.data)
-      if (data.MessageId === 'Wac_AppBootState') {
+      if (data.MessageId === 'App_LoadingStatus') {
         successfulLoad.value = true
         if (document.getElementById('office-alert')) {
           document.getElementById('office-alert').style.display = 'none'


### PR DESCRIPTION
- currently, the banner is still shown in successful previews
- the new event is present both in preview and edit modes