### PR TITLE
Feat/new auth workflow

### DIFF
--- a/dev/docker/ocis.idp.config.yaml
+++ b/dev/docker/ocis.idp.config.yaml
@@ -8,15 +8,19 @@ clients:
       - https://host.docker.internal:9200/
       - https://host.docker.internal:9200/oidc-callback.html
       - https://host.docker.internal:9200/oidc-silent-redirect.html
+      - https://host.docker.internal:9200/web-oidc-popup-callback
       - https://host.docker.internal:9201/
       - https://host.docker.internal:9201/oidc-callback.html
       - https://host.docker.internal:9201/oidc-silent-redirect.html
+      - https://host.docker.internal:9201/web-oidc-popup-callback
       - https://ocis.owncloud.test:10200/
       - https://ocis.owncloud.test:10200/oidc-callback.html
       - https://ocis.owncloud.test:10200/oidc-silent-redirect.html
+      - https://ocis.owncloud.test:10200/web-oidc-popup-callback
       - https://ocis.owncloud.test:10201/
       - https://ocis.owncloud.test:10201/oidc-callback.html
       - https://ocis.owncloud.test:10201/oidc-silent-redirect.html
+      - https://ocis.owncloud.test:10201/web-oidc-popup-callback
     origins:
       - https://host.docker.internal:9200
       - https://host.docker.internal:9201

--- a/packages/web-app-webfinger/src/views/Resolve.vue
+++ b/packages/web-app-webfinger/src/views/Resolve.vue
@@ -62,7 +62,7 @@ export default defineComponent({
       } catch (e) {
         console.error(e)
         if (e.response?.status === 401) {
-          return authService.handleAuthError(unref(route), { forceLogout: true })
+          return authService.handleAuthError(unref(route))
         }
         hasError.value = true
       }

--- a/packages/web-pkg/src/composables/authContext/useAuthService.ts
+++ b/packages/web-pkg/src/composables/authContext/useAuthService.ts
@@ -2,10 +2,12 @@ import { useService } from '../service'
 import { NavigationFailure } from 'vue-router'
 
 export interface AuthServiceInterface {
-  handleAuthError(route: any, options?: { forceLogout?: boolean }): any
+  handleAuthError(route: any): any
   signinSilent(): Promise<unknown>
   logoutUser(): Promise<void | NavigationFailure>
   getRefreshToken(): Promise<string>
+  showSessionExpiredModal(): void
+  loginUserPopup(): Promise<unknown>
 }
 
 export const useAuthService = (): AuthServiceInterface => {

--- a/packages/web-pkg/src/composables/authContext/useAuthService.ts
+++ b/packages/web-pkg/src/composables/authContext/useAuthService.ts
@@ -8,6 +8,7 @@ export interface AuthServiceInterface {
   getRefreshToken(): Promise<string>
   showSessionExpiredModal(): void
   loginUserPopup(): Promise<unknown>
+  reloadUserFromStorage(): Promise<void>
 }
 
 export const useAuthService = (): AuthServiceInterface => {

--- a/packages/web-pkg/src/composables/piniaStores/auth.ts
+++ b/packages/web-pkg/src/composables/piniaStores/auth.ts
@@ -5,6 +5,7 @@ export const useAuthStore = defineStore('auth', () => {
   const accessToken = ref<string>()
   const idpContextReady = ref(false)
   const userContextReady = ref(false)
+  const sessionExpired = ref(false)
   const publicLinkToken = ref<string>()
   const publicLinkPassword = ref<string>()
   const publicLinkType = ref<string>()
@@ -18,6 +19,9 @@ export const useAuthStore = defineStore('auth', () => {
   }
   const setUserContextReady = (value: boolean) => {
     userContextReady.value = value
+  }
+  const setSessionExpired = (value: boolean) => {
+    sessionExpired.value = value
   }
   const setPublicLinkContext = (context: {
     publicLinkToken: string
@@ -50,6 +54,7 @@ export const useAuthStore = defineStore('auth', () => {
     accessToken,
     idpContextReady,
     userContextReady,
+    sessionExpired,
     publicLinkToken,
     publicLinkPassword,
     publicLinkType,
@@ -58,6 +63,7 @@ export const useAuthStore = defineStore('auth', () => {
     setAccessToken,
     setIdpContextReady,
     setUserContextReady,
+    setSessionExpired,
     setPublicLinkContext,
     clearUserContext,
     clearPublicLinkContext

--- a/packages/web-pkg/src/composables/webWorkers/tokenTimerWorker/useTokenTimerWorker.ts
+++ b/packages/web-pkg/src/composables/webWorkers/tokenTimerWorker/useTokenTimerWorker.ts
@@ -24,10 +24,10 @@ export const useTokenTimerWorker = ({ authService }: { authService: AuthServiceI
 
         console.error('token renewal error:', error)
 
-        // log out user if they don't have a refresh token
+        // show session expired modal if there's no refresh token to renew silently
         const refreshToken = await authService.getRefreshToken()
         if (!refreshToken) {
-          return authService.logoutUser()
+          return authService.showSessionExpiredModal()
         }
       })
     }

--- a/packages/web-runtime/src/App.vue
+++ b/packages/web-runtime/src/App.vue
@@ -7,11 +7,13 @@
     </skip-to>
     <component :is="layout"></component>
     <modal-wrapper />
+    <session-expired-modal />
   </div>
 </template>
 <script lang="ts">
 import SkipTo from './components/SkipTo.vue'
 import ModalWrapper from './components/ModalWrapper.vue'
+import SessionExpiredModal from './components/SessionExpiredModal.vue'
 import { useLayout } from './composables/layout'
 import { computed, defineComponent, unref, watch } from 'vue'
 import { additionalTranslations } from './helpers/additionalTranslations' // eslint-disable-line
@@ -24,7 +26,8 @@ import { isEqual } from 'lodash-es'
 export default defineComponent({
   components: {
     SkipTo,
-    ModalWrapper
+    ModalWrapper,
+    SessionExpiredModal
   },
   setup() {
     const resourcesStore = useResourcesStore()

--- a/packages/web-runtime/src/components/SessionExpiredModal.vue
+++ b/packages/web-runtime/src/components/SessionExpiredModal.vue
@@ -1,7 +1,9 @@
 <template>
   <div v-if="sessionExpired" class="session-expired-overlay">
     <div class="oc-login-card session-expired-card">
-      <img class="oc-login-logo" :src="logoImg" alt="" :aria-hidden="true" />
+      <router-link to="/" aria-label="Home">
+        <img class="oc-login-logo" :src="logoImg" alt="" :aria-hidden="true" />
+      </router-link>
       <div class="oc-login-card-body oc-width-medium">
         <h2 class="oc-login-card-title" v-text="$gettext('Session expired')" />
         <p
@@ -36,7 +38,7 @@
 
 <script lang="ts">
 import { computed, defineComponent, onMounted, onUnmounted, ref } from 'vue'
-import { useAuthService, useAuthStore, useThemeStore } from '@ownclouders/web-pkg'
+import { useAuthService, useAuthStore, useRouter, useThemeStore } from '@ownclouders/web-pkg'
 import { storeToRefs } from 'pinia'
 
 export default defineComponent({
@@ -53,10 +55,21 @@ export default defineComponent({
     const logoImg = computed(() => currentTheme.value?.logo?.login)
     const footerSlogan = computed(() => currentTheme.value?.common?.slogan)
 
+    const router = useRouter()
+
+    const authRoutes = new Set([
+      'login', 'logout', 'oidcCallback', 'oidcSilentRedirect', 'oidcPopupCallback', 'accessDenied'
+    ])
+
     const dismiss = () => {
       reconnecting.value = false
       popupBlocked.value = false
       authStore.setSessionExpired(false)
+      // If reconnect succeeded while on a transient auth page, go home
+      const currentName = router.currentRoute.value?.name as string
+      if (authRoutes.has(currentName)) {
+        router.replace('/')
+      }
     }
 
     const handleStorageEvent = (event: StorageEvent) => {

--- a/packages/web-runtime/src/components/SessionExpiredModal.vue
+++ b/packages/web-runtime/src/components/SessionExpiredModal.vue
@@ -40,6 +40,7 @@
 import { computed, defineComponent, onMounted, onUnmounted, ref } from 'vue'
 import { useAuthService, useAuthStore, useRouter, useThemeStore } from '@ownclouders/web-pkg'
 import { storeToRefs } from 'pinia'
+import { loginWithPopupCoopFallback } from '../helpers/loginWithPopupCoopFallback'
 
 export default defineComponent({
   name: 'SessionExpiredModal',
@@ -90,24 +91,10 @@ export default defineComponent({
       reconnecting.value = true
       popupBlocked.value = false
 
-      // BroadcastChannel handles the COOP fallback where window.opener is null
-      const bc = new BroadcastChannel('oc_oidc_popup_complete')
-      const coopFallback = new Promise<void>((resolve) => {
-        bc.addEventListener('message', async (e) => {
-          if (e.data?.type === 'complete') {
-            bc.close()
-            await authService.reloadUserFromStorage()
-            resolve()
-          }
-        })
-      })
-
       try {
-        await Promise.race([authService.loginUserPopup(), coopFallback])
-        bc.close()
+        await loginWithPopupCoopFallback(() => authService.loginUserPopup())
         dismiss()
       } catch {
-        bc.close()
         reconnecting.value = false
         popupBlocked.value = true
       }

--- a/packages/web-runtime/src/components/SessionExpiredModal.vue
+++ b/packages/web-runtime/src/components/SessionExpiredModal.vue
@@ -76,10 +76,25 @@ export default defineComponent({
     const reconnect = async () => {
       reconnecting.value = true
       popupBlocked.value = false
+
+      // BroadcastChannel handles the COOP fallback where window.opener is null
+      const bc = new BroadcastChannel('oc_oidc_popup_complete')
+      const coopFallback = new Promise<void>((resolve) => {
+        bc.addEventListener('message', async (e) => {
+          if (e.data?.type === 'complete') {
+            bc.close()
+            await authService.reloadUserFromStorage()
+            resolve()
+          }
+        })
+      })
+
       try {
-        await authService.loginUserPopup()
+        await Promise.race([authService.loginUserPopup(), coopFallback])
+        bc.close()
         dismiss()
       } catch {
+        bc.close()
         reconnecting.value = false
         popupBlocked.value = true
       }

--- a/packages/web-runtime/src/components/SessionExpiredModal.vue
+++ b/packages/web-runtime/src/components/SessionExpiredModal.vue
@@ -1,0 +1,108 @@
+<template>
+  <div v-if="sessionExpired" class="session-expired-overlay">
+    <div class="oc-login-card session-expired-card">
+      <img class="oc-login-logo" :src="logoImg" alt="" :aria-hidden="true" />
+      <div class="oc-login-card-body oc-width-medium">
+        <h2 class="oc-login-card-title" v-text="$gettext('Session expired')" />
+        <p
+          v-if="popupBlocked"
+          v-text="$gettext('Popup was blocked. Please allow popups for this page in your browser and try again.')"
+        />
+        <p
+          v-else
+          v-text="
+            $gettext(
+              'Your session has expired. If you are logged in on another tab, this page will resume automatically. Otherwise, click Reconnect to log in again.'
+            )
+          "
+        />
+      </div>
+      <div class="oc-login-card-footer oc-pt-rm">
+        <p>{{ footerSlogan }}</p>
+      </div>
+    </div>
+    <oc-button
+      class="oc-mt-m oc-width-medium"
+      size="large"
+      appearance="filled"
+      variation="primary"
+      :disabled="reconnecting"
+      @click="reconnect"
+    >
+      {{ reconnecting ? $gettext('Opening login…') : $gettext('Reconnect') }}
+    </oc-button>
+  </div>
+</template>
+
+<script lang="ts">
+import { computed, defineComponent, onMounted, onUnmounted, ref } from 'vue'
+import { useAuthService, useAuthStore, useThemeStore } from '@ownclouders/web-pkg'
+import { storeToRefs } from 'pinia'
+
+export default defineComponent({
+  name: 'SessionExpiredModal',
+  setup() {
+    const authService = useAuthService()
+    const authStore = useAuthStore()
+    const themeStore = useThemeStore()
+    const { currentTheme } = storeToRefs(themeStore)
+    const { sessionExpired } = storeToRefs(authStore)
+
+    const reconnecting = ref(false)
+    const popupBlocked = ref(false)
+    const logoImg = computed(() => currentTheme.value?.logo?.login)
+    const footerSlogan = computed(() => currentTheme.value?.common?.slogan)
+
+    const dismiss = () => {
+      reconnecting.value = false
+      popupBlocked.value = false
+      authStore.setSessionExpired(false)
+    }
+
+    const handleStorageEvent = (event: StorageEvent) => {
+      if (!event.key?.startsWith('oc_oAuth.') || !event.newValue) {
+        return
+      }
+      // Only attempt cross-tab reconnect when the session is actually expired
+      if (!authStore.sessionExpired) {
+        return
+      }
+      authService.signinSilent().then(dismiss).catch(() => {})
+    }
+
+    onMounted(() => window.addEventListener('storage', handleStorageEvent))
+    onUnmounted(() => window.removeEventListener('storage', handleStorageEvent))
+
+    const reconnect = async () => {
+      reconnecting.value = true
+      popupBlocked.value = false
+      try {
+        await authService.loginUserPopup()
+        dismiss()
+      } catch {
+        reconnecting.value = false
+        popupBlocked.value = true
+      }
+    }
+
+    return { sessionExpired, logoImg, footerSlogan, reconnecting, popupBlocked, reconnect }
+  }
+})
+</script>
+
+<style lang="scss" scoped>
+.session-expired-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 10000;
+  background: rgba(0, 0, 0, 0.75);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+}
+
+.session-expired-card {
+  text-align: center;
+}
+</style>

--- a/packages/web-runtime/src/composables/layout/useLayout.ts
+++ b/packages/web-runtime/src/composables/layout/useLayout.ts
@@ -21,6 +21,7 @@ export const useLayout = (options?: LayoutOptions) => {
       'logout',
       'oidcCallback',
       'oidcSilentRedirect',
+      'oidcPopupCallback',
       'resolvePublicLink',
       'accessDenied'
     ]

--- a/packages/web-runtime/src/helpers/loginWithPopupCoopFallback.ts
+++ b/packages/web-runtime/src/helpers/loginWithPopupCoopFallback.ts
@@ -1,0 +1,60 @@
+import { authService } from '../services/auth'
+
+const POPUP_COMPLETE_CHANNEL = 'oc_oidc_popup_complete'
+const FALLBACK_TIMEOUT_MS = 120_000
+// Grace period after the popup flow rejects, to let an already-dispatched COOP
+// "complete" message (posted by the popup just before it closed) be delivered.
+// If none arrives within this window, the popup was genuinely blocked or dismissed.
+const POPUP_REJECTION_GRACE_MS = 2_000
+
+/**
+ * Runs popup OIDC login and waits for the COOP BroadcastChannel fallback when the popup
+ * cannot use window.opener.
+ *
+ * A popup promise rejection does not fail the flow immediately: under COOP the opener
+ * handshake can reject even though the popup authenticated successfully and a "complete"
+ * message is already in flight. We wait a short grace period for that message before
+ * surfacing the failure, so a genuinely blocked popup still fails fast.
+ */
+export const loginWithPopupCoopFallback = (popupLogin: () => Promise<unknown>): Promise<void> => {
+  return new Promise((resolve, reject) => {
+    const bc = new BroadcastChannel(POPUP_COMPLETE_CHANNEL)
+    let settled = false
+    let graceTimeoutId: ReturnType<typeof setTimeout>
+
+    const finish = (callback: () => void) => {
+      if (settled) {
+        return
+      }
+      settled = true
+      clearTimeout(timeoutId)
+      clearTimeout(graceTimeoutId)
+      bc.close()
+      callback()
+    }
+
+    const timeoutId = setTimeout(() => {
+      finish(() => reject(new Error('popup_auth_timeout')))
+    }, FALLBACK_TIMEOUT_MS)
+
+    bc.addEventListener('message', async (e) => {
+      if (e.data?.type !== 'complete') {
+        return
+      }
+      try {
+        await authService.reloadUserFromStorage()
+        finish(resolve)
+      } catch (error) {
+        finish(() => reject(error))
+      }
+    })
+
+    popupLogin()
+      .then(() => finish(resolve))
+      .catch((error) => {
+        graceTimeoutId = setTimeout(() => {
+          finish(() => reject(error))
+        }, POPUP_REJECTION_GRACE_MS)
+      })
+  })
+}

--- a/packages/web-runtime/src/helpers/silentRedirect.ts
+++ b/packages/web-runtime/src/helpers/silentRedirect.ts
@@ -1,1 +1,2 @@
 export const isSilentRedirectRoute = () => window.location.pathname === '/web-oidc-silent-redirect'
+export const isPopupCallbackRoute = () => window.location.pathname === '/web-oidc-popup-callback'

--- a/packages/web-runtime/src/pages/accessDenied.vue
+++ b/packages/web-runtime/src/pages/accessDenied.vue
@@ -1,7 +1,9 @@
 <template>
   <div class="oc-height-viewport oc-flex oc-flex-column oc-flex-center oc-flex-middle">
     <div class="oc-login-card">
-      <img class="oc-login-logo" :src="logoImg" alt="" :aria-hidden="true" />
+      <router-link to="/" aria-label="Home">
+        <img class="oc-login-logo" :src="logoImg" alt="" :aria-hidden="true" />
+      </router-link>
       <div class="oc-login-card-body oc-width-medium">
         <h2 class="oc-login-card-title" v-text="cardTitle" />
         <p v-text="cardHint" />
@@ -60,6 +62,7 @@ export default defineComponent({
     const lowAssuranceLevelError = computed(
       () => queryItemAsString(unref(reasonQuery)) === 'lowAssuranceLevel'
     )
+    const isLoginError = computed(() => queryItemAsString(unref(reasonQuery)) === 'loginError')
 
     const { $gettext } = useGettext()
 
@@ -71,12 +74,20 @@ export default defineComponent({
       if (unref(lowAssuranceLevelError)) {
         return $gettext('Cannot log in')
       }
+      if (unref(isLoginError)) {
+        return $gettext('Error signing in')
+      }
       return $gettext('Not logged in')
     })
     const cardHint = computed(() => {
       if (unref(lowAssuranceLevelError)) {
         return $gettext(
           'Please login to your CERN account using the CERN credentials instead of a guest account.'
+        )
+      }
+      if (unref(isLoginError)) {
+        return $gettext(
+          'There was an error while trying to sign you in. Please try again or contact your administrator if the problem persists.'
         )
       }
       return $gettext(

--- a/packages/web-runtime/src/pages/login.vue
+++ b/packages/web-runtime/src/pages/login.vue
@@ -18,6 +18,7 @@
 <script lang="ts">
 import { defineComponent, ref, unref } from 'vue'
 import { authService } from '../services/auth'
+import { loginWithPopupCoopFallback } from '../helpers/loginWithPopupCoopFallback'
 import {
   AppLoadingSpinner,
   queryItemAsString,
@@ -43,28 +44,13 @@ export default defineComponent({
     const login = async () => {
       clicked.value = true
 
-      // BroadcastChannel handles the COOP fallback where window.opener is null
-      const bc = new BroadcastChannel('oc_oidc_popup_complete')
-      const coopFallback = new Promise<void>((resolve) => {
-        bc.addEventListener('message', async (e) => {
-          if (e.data?.type === 'complete') {
-            bc.close()
-            await authService.reloadUserFromStorage()
-            resolve()
-          }
-        })
-      })
-
       try {
-        await Promise.race([
-          authService.loginUser(queryItemAsString(unref(redirectUrl))),
-          coopFallback
-        ])
-        bc.close()
+        await loginWithPopupCoopFallback(() =>
+          authService.loginUser(queryItemAsString(unref(redirectUrl)))
+        )
         router.replace(queryItemAsString(unref(redirectUrl)) || '/')
       } catch {
-        bc.close()
-        // popup was blocked or dismissed — hint is already visible via clicked.value
+        // popup was blocked or dismissed, hint is already visible via clicked.value
       }
     }
 

--- a/packages/web-runtime/src/pages/login.vue
+++ b/packages/web-runtime/src/pages/login.vue
@@ -42,11 +42,28 @@ export default defineComponent({
 
     const login = async () => {
       clicked.value = true
+
+      // BroadcastChannel handles the COOP fallback where window.opener is null
+      const bc = new BroadcastChannel('oc_oidc_popup_complete')
+      const coopFallback = new Promise<void>((resolve) => {
+        bc.addEventListener('message', async (e) => {
+          if (e.data?.type === 'complete') {
+            bc.close()
+            await authService.reloadUserFromStorage()
+            resolve()
+          }
+        })
+      })
+
       try {
-        await authService.loginUser(queryItemAsString(unref(redirectUrl)))
-        // Popup flow doesn't redirect automatically — navigate to the original target
+        await Promise.race([
+          authService.loginUser(queryItemAsString(unref(redirectUrl))),
+          coopFallback
+        ])
+        bc.close()
         router.replace(queryItemAsString(unref(redirectUrl)) || '/')
       } catch {
+        bc.close()
         // popup was blocked or dismissed — hint is already visible via clicked.value
       }
     }

--- a/packages/web-runtime/src/pages/login.vue
+++ b/packages/web-runtime/src/pages/login.vue
@@ -1,25 +1,79 @@
 <template>
-  <div class="oc-width-1-1 oc-height-1-1">
+  <div v-if="isEmbedMode" class="embed-login">
+    <p v-text="$gettext('Click below to log in.')" />
+    <p
+      v-if="clicked"
+      class="embed-login-hint"
+      v-text="$gettext('If no window appeared, your browser blocked the popup. Allow popups for this page and try again.')"
+    />
+    <oc-button class="oc-mt-s" appearance="filled" variation="primary" @click="login">
+      {{ $gettext('Log in') }}
+    </oc-button>
+  </div>
+  <div v-else class="oc-width-1-1 oc-height-1-1">
     <app-loading-spinner />
   </div>
 </template>
 
 <script lang="ts">
+import { defineComponent, ref, unref } from 'vue'
 import { authService } from '../services/auth'
-import { queryItemAsString, useRouteQuery } from '@ownclouders/web-pkg'
-import { defineComponent, unref } from 'vue'
-import { AppLoadingSpinner } from '@ownclouders/web-pkg'
+import {
+  AppLoadingSpinner,
+  queryItemAsString,
+  useEmbedMode,
+  useRouter,
+  useRouteQuery
+} from '@ownclouders/web-pkg'
 
 export default defineComponent({
   name: 'LoginPage',
-  components: {
-    AppLoadingSpinner
-  },
+  components: { AppLoadingSpinner },
   setup() {
+    const { isEnabled: isEmbedModeEnabled } = useEmbedMode()
     const redirectUrl = useRouteQuery('redirectUrl')
-    authService.loginUser(queryItemAsString(unref(redirectUrl)))
+    const isEmbedMode = unref(isEmbedModeEnabled)
+    const clicked = ref(false)
+    const router = useRouter()
 
-    return {}
+    if (!isEmbedMode) {
+      authService.loginUser(queryItemAsString(unref(redirectUrl)))
+    }
+
+    const login = async () => {
+      clicked.value = true
+      try {
+        await authService.loginUser(queryItemAsString(unref(redirectUrl)))
+        // Popup flow doesn't redirect automatically — navigate to the original target
+        router.replace(queryItemAsString(unref(redirectUrl)) || '/')
+      } catch {
+        // popup was blocked or dismissed — hint is already visible via clicked.value
+      }
+    }
+
+    return { isEmbedMode, clicked, login }
   }
 })
 </script>
+
+<style lang="scss" scoped>
+.embed-login {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: var(--oc-space-small);
+  background: var(--oc-color-background-default);
+  color: var(--oc-color-text-default);
+  padding: var(--oc-space-medium);
+  text-align: center;
+}
+
+.embed-login-hint {
+  color: var(--oc-color-text-muted);
+  font-size: var(--oc-font-size-small);
+  max-width: 320px;
+}
+</style>

--- a/packages/web-runtime/src/pages/oidcCallback.vue
+++ b/packages/web-runtime/src/pages/oidcCallback.vue
@@ -7,7 +7,9 @@
 
   <!-- Normal / silent redirect: existing login card -->
   <div v-else class="oc-login-card oc-position-center">
-    <img class="oc-login-logo" :src="logoImg" alt="" :aria-hidden="true" />
+    <router-link to="/" aria-label="Home">
+      <img class="oc-login-logo" :src="logoImg" alt="" :aria-hidden="true" />
+    </router-link>
     <div v-show="error" class="oc-login-card-body">
       <h2 v-translate class="oc-login-card-title">Authentication failed</h2>
       <p v-translate>Please contact the administrator if this error persists.</p>

--- a/packages/web-runtime/src/pages/oidcCallback.vue
+++ b/packages/web-runtime/src/pages/oidcCallback.vue
@@ -72,6 +72,8 @@ export default defineComponent({
 
       if (unref(route).path === '/web-oidc-silent-redirect') {
         authService.signInSilentCallback()
+      } else if (unref(route).path === '/web-oidc-popup-callback') {
+        authService.signInPopupCallback()
       } else {
         authService.signInCallback()
       }

--- a/packages/web-runtime/src/pages/oidcCallback.vue
+++ b/packages/web-runtime/src/pages/oidcCallback.vue
@@ -1,5 +1,12 @@
 <template>
-  <div class="oc-login-card oc-position-center">
+  <!-- Popup window: bare page, no chrome, just status text -->
+  <div v-if="isPopupCallback" class="popup-callback">
+    <span v-if="error" v-translate>Authentication failed. Please close this window and try again.</span>
+    <span v-else v-translate>Logging you in…</span>
+  </div>
+
+  <!-- Normal / silent redirect: existing login card -->
+  <div v-else class="oc-login-card oc-position-center">
     <img class="oc-login-logo" :src="logoImg" alt="" :aria-hidden="true" />
     <div v-show="error" class="oc-login-card-body">
       <h2 v-translate class="oc-login-card-title">Authentication failed</h2>
@@ -73,7 +80,10 @@ export default defineComponent({
       if (unref(route).path === '/web-oidc-silent-redirect') {
         authService.signInSilentCallback()
       } else if (unref(route).path === '/web-oidc-popup-callback') {
-        authService.signInPopupCallback()
+        authService.signInPopupCallback().catch((e) => {
+          console.error('Popup callback failed:', e)
+          error.value = true
+        })
       } else {
         authService.signInCallback()
       }
@@ -88,11 +98,27 @@ export default defineComponent({
       window.removeEventListener('message', handleRequestedTokenEvent)
     })
 
+    const isPopupCallback = unref(route).path === '/web-oidc-popup-callback'
+
     return {
       error,
+      isPopupCallback,
       logoImg,
       footerSlogan
     }
   }
 })
 </script>
+
+<style lang="scss" scoped>
+.popup-callback {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--oc-color-background-default);
+  color: var(--oc-color-text-default);
+  font-size: var(--oc-font-size-medium);
+}
+</style>

--- a/packages/web-runtime/src/pages/oidcCallback.vue
+++ b/packages/web-runtime/src/pages/oidcCallback.vue
@@ -81,8 +81,19 @@ export default defineComponent({
         authService.signInSilentCallback()
       } else if (unref(route).path === '/web-oidc-popup-callback') {
         authService.signInPopupCallback().catch((e) => {
-          console.error('Popup callback failed:', e)
-          error.value = true
+          if (e?.message?.includes('window.opener')) {
+            // COOP: window.opener severed by SSO headers — fall back to BroadcastChannel
+            authService
+              .signInCallbackForCOOPFallback()
+              .then(() => window.close())
+              .catch((e2) => {
+                console.error('Popup COOP fallback failed:', e2)
+                error.value = true
+              })
+          } else {
+            console.error('Popup callback failed:', e)
+            error.value = true
+          }
         })
       } else {
         authService.signInCallback()

--- a/packages/web-runtime/src/router/index.ts
+++ b/packages/web-runtime/src/router/index.ts
@@ -53,6 +53,12 @@ const routes = [
     meta: { title: $gettext('Oidc redirect'), authContext: 'anonymous' }
   },
   {
+    path: '/web-oidc-popup-callback',
+    name: 'oidcPopupCallback',
+    component: OidcCallbackPage,
+    meta: { title: $gettext('Oidc popup callback'), authContext: 'anonymous' }
+  },
+  {
     path: '/f/:fileId',
     name: 'resolvePrivateLink',
     component: ResolvePrivateLinkPage,

--- a/packages/web-runtime/src/router/setupAuthGuard.ts
+++ b/packages/web-runtime/src/router/setupAuthGuard.ts
@@ -26,11 +26,9 @@ export const setupAuthGuard = (router: Router) => {
     const authStore = useAuthStore()
     await authService.initializeContext(to)
 
-    // vue-router currently (4.1.6) does not cancel navigations when a new one is triggered
-    // we need to guard this case to be able to show the access denied page
-    // and not be redirected to the login page
-    if (authService.hasAuthErrorOccurred) {
-      return to.name === 'accessDenied' || { name: 'accessDenied' }
+    // block navigation while session expired modal is active
+    if (authStore.sessionExpired) {
+      return false
     }
 
     if (isPublicLinkContextRequired(router, to)) {
@@ -71,12 +69,6 @@ export const setupAuthGuard = (router: Router) => {
     }
 
     return true
-  })
-  router.afterEach((to) => {
-    if (to.name !== 'accessDenied') {
-      return
-    }
-    authService.hasAuthErrorOccurred = false
   })
 }
 

--- a/packages/web-runtime/src/services/auth/authService.ts
+++ b/packages/web-runtime/src/services/auth/authService.ts
@@ -8,7 +8,8 @@ import {
   CapabilityStore,
   ConfigStore,
   useTokenTimerWorker,
-  AuthServiceInterface
+  AuthServiceInterface,
+  useEmbedMode
 } from '@ownclouders/web-pkg'
 import { RouteLocation, Router } from 'vue-router'
 import {
@@ -19,7 +20,7 @@ import {
   isUserContextRequired
 } from '../../router'
 import { unref } from 'vue'
-import { Ability } from '@ownclouders/web-client'
+import { Ability, urlJoin } from '@ownclouders/web-client'
 import { Language } from 'vue3-gettext'
 import { PublicLinkType } from '@ownclouders/web-client'
 import { WebWorkersStore } from '@ownclouders/web-pkg'
@@ -246,6 +247,13 @@ export class AuthService implements AuthServiceInterface {
   }
 
   public loginUser(redirectUrl?: string) {
+    const { isEnabled: isEmbedModeEnable } = useEmbedMode()
+    // if embed mode is enabled, use popup login instead of a redirect
+    if (unref(isEmbedModeEnable)) {
+      return this.userManager.signinPopup({
+        redirect_uri: urlJoin(unref(this.configStore.serverUrl), 'web-oidc-popup-callback')
+      })
+    }
     this.userManager.setPostLoginRedirectUrl(redirectUrl)
     return this.userManager.signinRedirect()
   }
@@ -298,6 +306,10 @@ export class AuthService implements AuthServiceInterface {
    */
   public async signInSilentCallback() {
     await this.userManager.signinSilentCallback(this.buildSignInCallbackUrl())
+  }
+
+  public async signInPopupCallback() {
+    await this.userManager.signinPopupCallback(this.buildSignInCallbackUrl())
   }
 
   /**

--- a/packages/web-runtime/src/services/auth/authService.ts
+++ b/packages/web-runtime/src/services/auth/authService.ts
@@ -24,7 +24,7 @@ import { Ability, urlJoin } from '@ownclouders/web-client'
 import { Language } from 'vue3-gettext'
 import { PublicLinkType } from '@ownclouders/web-client'
 import { WebWorkersStore } from '@ownclouders/web-pkg'
-import { isSilentRedirectRoute } from '../../helpers/silentRedirect'
+import { isSilentRedirectRoute, isPopupCallbackRoute } from '../../helpers/silentRedirect'
 
 export class AuthService implements AuthServiceInterface {
   private clientService: ClientService
@@ -45,7 +45,6 @@ export class AuthService implements AuthServiceInterface {
   // number of seconds before an access token is to expire to raise the accessTokenExpiring event
   private accessTokenExpiryThreshold = 10
 
-  public hasAuthErrorOccurred: boolean
   public lowAssuranceError: boolean
 
   public initialize(
@@ -62,7 +61,6 @@ export class AuthService implements AuthServiceInterface {
     this.configStore = configStore
     this.clientService = clientService
     this.router = router
-    this.hasAuthErrorOccurred = false
     this.lowAssuranceError = false
     this.ability = ability
     this.language = language
@@ -115,9 +113,9 @@ export class AuthService implements AuthServiceInterface {
         accessTokenExpiryThreshold: this.accessTokenExpiryThreshold
       })
 
-      // don't load worker in the silent redirect iframe
+      // don't load worker in the silent redirect iframe or popup callback window
       const isSilentRedirect = isSilentRedirectRoute()
-      if (!this.tokenTimerWorker && !isSilentRedirect) {
+      if (!this.tokenTimerWorker && !isSilentRedirect && !isPopupCallbackRoute()) {
         const { options } = this.configStore
 
         if (!options.embed?.enabled || !options.embed?.delegateAuthentication) {
@@ -146,7 +144,7 @@ export class AuthService implements AuthServiceInterface {
         this.userManager.events.addAccessTokenExpired((...args): void => {
           const handleExpirationError = () => {
             console.error('AccessToken Expired：', ...args)
-            this.handleAuthError(unref(this.router.currentRoute), { forceLogout: true })
+            this.handleAuthError(unref(this.router.currentRoute))
           }
 
           // retry silent signin once, force logout if it fails
@@ -184,11 +182,8 @@ export class AuthService implements AuthServiceInterface {
           this.resetStateAfterUserLogout()
 
           if (this.userManager.unloadReason === 'authError') {
-            this.hasAuthErrorOccurred = true
-            return this.router.push({
-              name: 'accessDenied',
-              query: { redirectUrl: unref(this.router.currentRoute)?.fullPath }
-            })
+            this.authStore.setSessionExpired(true)
+            return
           }
 
           // handle redirect after logout
@@ -244,6 +239,17 @@ export class AuthService implements AuthServiceInterface {
         }
       }
     }
+  }
+
+  public showSessionExpiredModal() {
+    this.tokenTimerWorker?.resetTokenTimer()
+    this.authStore.setSessionExpired(true)
+  }
+
+  public loginUserPopup() {
+    return this.userManager.signinPopup({
+      redirect_uri: urlJoin(unref(this.configStore.serverUrl), 'web-oidc-popup-callback')
+    })
   }
 
   public loginUser(redirectUrl?: string) {
@@ -309,7 +315,9 @@ export class AuthService implements AuthServiceInterface {
   }
 
   public async signInPopupCallback() {
-    await this.userManager.signinPopupCallback(this.buildSignInCallbackUrl())
+    // Use window.location.href directly — more reliable than the router-reconstructed URL,
+    // and avoids issues when window.opener is null (e.g. COOP headers from cross-origin SSO).
+    await this.userManager.signinPopupCallback(window.location.href)
   }
 
   /**
@@ -320,10 +328,12 @@ export class AuthService implements AuthServiceInterface {
     return '/?' + new URLSearchParams(currentQuery as Record<string, string>).toString()
   }
 
-  public async handleAuthError(
-    route: RouteLocation,
-    { forceLogout = false }: { forceLogout?: boolean } = {}
-  ) {
+  public async handleAuthError(route: RouteLocation) {
+    // guard against re-entrant calls while already showing session expired modal
+    if (this.authStore.sessionExpired) {
+      return
+    }
+
     if (isPublicLinkContextRequired(this.router, route)) {
       const token = extractPublicLinkToken(route)
       this.publicLinkManager.clear(token)
@@ -333,27 +343,23 @@ export class AuthService implements AuthServiceInterface {
         query: { redirectUrl: route.fullPath }
       })
     }
+
     if (isUserContextRequired(this.router, route) || isIdpContextRequired(this.router, route)) {
-      if (forceLogout) {
-        this.tokenTimerWorker?.resetTokenTimer()
-        await this.logoutUser()
-        return
-      }
-
-      const user = await this.userManager.getUser()
-      if (user?.expires_in !== undefined && user.expires_in < 0) {
-        // token expired, simply return and let the regular auth flow do its thing
-        return
-      }
-
-      await this.userManager.removeUser('authError')
       this.tokenTimerWorker?.resetTokenTimer()
+
+      // Only show the modal when the session was already active.
+      // On initial page load the context is not ready yet, so we let the
+      // auth guard redirect to /login (full SSO redirect in normal mode,
+      // popup page in embed mode) as usual.
+      if (!this.authStore.userContextReady) {
+        return
+      }
+
+      this.authStore.setSessionExpired(true)
       return
     }
-    // authGuard is taking care of redirecting the user to the
-    // accessDenied page if hasAuthErrorOccurred is set to true
-    // we can't push the route ourselves, see authGuard for details.
-    this.hasAuthErrorOccurred = true
+
+    this.authStore.setSessionExpired(true)
   }
 
   private isLowAssuranceLevelError(e: unknown): boolean {

--- a/packages/web-runtime/src/services/auth/authService.ts
+++ b/packages/web-runtime/src/services/auth/authService.ts
@@ -321,6 +321,29 @@ export class AuthService implements AuthServiceInterface {
   }
 
   /**
+   * COOP fallback for popup callback when window.opener is null.
+   * Processes the auth code via the redirect flow, then signals the opener
+   * via BroadcastChannel (same-origin, not affected by COOP).
+   */
+  public async signInCallbackForCOOPFallback() {
+    await this.userManager.signinRedirectCallback(window.location.href)
+    const bc = new BroadcastChannel('oc_oidc_popup_complete')
+    bc.postMessage({ type: 'complete' })
+    bc.close()
+  }
+
+  /**
+   * Called by the opener after BroadcastChannel signals popup completed.
+   * Re-reads the user from storage and updates the auth context.
+   */
+  public async reloadUserFromStorage() {
+    const user = await this.userManager.getUser()
+    if (user?.access_token) {
+      await this.userManager.updateContext(user.access_token, true)
+    }
+  }
+
+  /**
    * craft a url that the parser in oidc-client-ts can handle…
    */
   private buildSignInCallbackUrl() {

--- a/packages/web-runtime/src/services/auth/authService.ts
+++ b/packages/web-runtime/src/services/auth/authService.ts
@@ -367,21 +367,16 @@ export class AuthService implements AuthServiceInterface {
       })
     }
 
-    if (isUserContextRequired(this.router, route) || isIdpContextRequired(this.router, route)) {
+    // If the user context was never established (startup or login failure),
+    // navigate to the access denied page with an appropriate message rather
+    // than showing the "session expired" modal which implies a prior session.
+    if (!this.authStore.userContextReady) {
       this.tokenTimerWorker?.resetTokenTimer()
-
-      // Only show the modal when the session was already active.
-      // On initial page load the context is not ready yet, so we let the
-      // auth guard redirect to /login (full SSO redirect in normal mode,
-      // popup page in embed mode) as usual.
-      if (!this.authStore.userContextReady) {
-        return
-      }
-
-      this.authStore.setSessionExpired(true)
-      return
+      return this.router.push({ name: 'accessDenied', query: { reason: 'loginError' } })
     }
 
+    // User WAS logged in — this is a mid-session auth failure.
+    this.tokenTimerWorker?.resetTokenTimer()
     this.authStore.setSessionExpired(true)
   }
 

--- a/packages/web-runtime/src/services/auth/userManager.ts
+++ b/packages/web-runtime/src/services/auth/userManager.ts
@@ -60,8 +60,15 @@ export class UserManager extends OidcUserManager {
       prefix: storePrefix,
       store: browserStorage
     })
+    // Always use localStorage for stateStore so popup windows (same-origin)
+    // can access the PKCE state even when window.opener is severed by COOP headers.
+    const stateStore = new WebStorageStateStore({
+      prefix: storePrefix,
+      store: localStorage
+    })
     const openIdConfig: UserManagerSettings = {
       userStore,
+      stateStore,
       redirect_uri: buildUrl(router, '/oidc-callback.html'),
       silent_redirect_uri: buildUrl(router, '/oidc-silent-redirect.html'),
 

--- a/packages/web-runtime/tests/unit/components/SessionExpiredModal.spec.ts
+++ b/packages/web-runtime/tests/unit/components/SessionExpiredModal.spec.ts
@@ -1,5 +1,5 @@
 import { defaultPlugins, shallowMount, createTestingPinia } from '@ownclouders/web-test-helpers'
-import { flushPromises, nextTick } from '@vue/test-utils'
+import { flushPromises } from '@vue/test-utils'
 import SessionExpiredModal from '../../../src/components/SessionExpiredModal.vue'
 import { useAuthService, useAuthStore } from '@ownclouders/web-pkg'
 
@@ -49,13 +49,17 @@ describe('SessionExpiredModal', () => {
   })
 
   it('reconnect: shows popup-blocked hint when popup throws', async () => {
+    vi.useFakeTimers()
     mockAuthService.loginUserPopup.mockRejectedValue(new Error('Popup blocked'))
     const { wrapper } = getWrapper({ sessionExpired: true })
 
     await wrapper.find('oc-button-stub').trigger('click')
+    // popup rejection waits for the COOP grace period before surfacing the failure
+    await vi.advanceTimersByTimeAsync(2000)
     await flushPromises()
 
     expect(wrapper.text()).toContain('Popup was blocked')
+    vi.useRealTimers()
   })
 
   it('dismisses when storage event signals another tab refreshed the token', async () => {

--- a/packages/web-runtime/tests/unit/components/SessionExpiredModal.spec.ts
+++ b/packages/web-runtime/tests/unit/components/SessionExpiredModal.spec.ts
@@ -1,0 +1,99 @@
+import { defaultPlugins, shallowMount, createTestingPinia } from '@ownclouders/web-test-helpers'
+import { flushPromises, nextTick } from '@vue/test-utils'
+import SessionExpiredModal from '../../../src/components/SessionExpiredModal.vue'
+import { useAuthService, useAuthStore } from '@ownclouders/web-pkg'
+
+const mockAuthService = {
+  loginUserPopup: vi.fn(),
+  signinSilent: vi.fn(),
+  reloadUserFromStorage: vi.fn()
+}
+
+vi.mock('@ownclouders/web-pkg', async (importOriginal) => ({
+  ...(await importOriginal<any>()),
+  useAuthService: vi.fn()
+}))
+
+describe('SessionExpiredModal', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(useAuthService).mockReturnValue(mockAuthService as any)
+    vi.stubGlobal(
+      'BroadcastChannel',
+      vi.fn(() => ({ addEventListener: vi.fn(), close: vi.fn() }))
+    )
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('is hidden when sessionExpired is false', () => {
+    const { wrapper } = getWrapper({ sessionExpired: false })
+    expect(wrapper.find('.session-expired-overlay').exists()).toBe(false)
+  })
+
+  it('is visible when sessionExpired is true', () => {
+    const { wrapper } = getWrapper({ sessionExpired: true })
+    expect(wrapper.find('.session-expired-overlay').exists()).toBe(true)
+  })
+
+  it('reconnect: dismisses modal on successful popup login', async () => {
+    mockAuthService.loginUserPopup.mockResolvedValue(undefined)
+    const { wrapper, authStore } = getWrapper({ sessionExpired: true })
+
+    await wrapper.find('oc-button-stub').trigger('click')
+    await flushPromises()
+
+    expect(authStore.sessionExpired).toBe(false)
+  })
+
+  it('reconnect: shows popup-blocked hint when popup throws', async () => {
+    mockAuthService.loginUserPopup.mockRejectedValue(new Error('Popup blocked'))
+    const { wrapper } = getWrapper({ sessionExpired: true })
+
+    await wrapper.find('oc-button-stub').trigger('click')
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('Popup was blocked')
+  })
+
+  it('dismisses when storage event signals another tab refreshed the token', async () => {
+    mockAuthService.signinSilent.mockResolvedValue(undefined)
+    const { authStore } = getWrapper({ sessionExpired: true })
+
+    window.dispatchEvent(
+      new StorageEvent('storage', { key: 'oc_oAuth.user:something', newValue: '{"token":"x"}' })
+    )
+    await flushPromises()
+
+    expect(mockAuthService.signinSilent).toHaveBeenCalled()
+    expect(authStore.sessionExpired).toBe(false)
+  })
+
+  it('ignores storage events for unrelated keys', async () => {
+    mockAuthService.signinSilent.mockResolvedValue(undefined)
+    const { authStore } = getWrapper({ sessionExpired: true })
+
+    window.dispatchEvent(new StorageEvent('storage', { key: 'unrelated', newValue: 'v' }))
+    await flushPromises()
+
+    expect(mockAuthService.signinSilent).not.toHaveBeenCalled()
+    expect(authStore.sessionExpired).toBe(true)
+  })
+})
+
+function getWrapper({ sessionExpired = false } = {}) {
+  // Create pinia first so we can set initial state before the component mounts
+  const pinia = createTestingPinia({ stubActions: false })
+  const authStore = useAuthStore(pinia)
+  authStore.sessionExpired = sessionExpired
+
+  const wrapper = shallowMount(SessionExpiredModal, {
+    global: {
+      plugins: [...defaultPlugins({ pinia: false }), pinia]
+    }
+  })
+
+  return { wrapper, authStore }
+}

--- a/packages/web-runtime/tests/unit/helpers/loginWithPopupCoopFallback.spec.ts
+++ b/packages/web-runtime/tests/unit/helpers/loginWithPopupCoopFallback.spec.ts
@@ -1,0 +1,51 @@
+import { loginWithPopupCoopFallback } from '../../../src/helpers/loginWithPopupCoopFallback'
+import { authService } from '../../../src/services/auth'
+
+vi.mock('../../../src/services/auth', () => ({
+  authService: {
+    reloadUserFromStorage: vi.fn()
+  }
+}))
+
+describe('loginWithPopupCoopFallback', () => {
+  afterEach(() => {
+    vi.clearAllMocks()
+    vi.useRealTimers()
+  })
+
+  it('resolves when popup login succeeds', async () => {
+    const popupLogin = vi.fn().mockResolvedValue(undefined)
+
+    await expect(loginWithPopupCoopFallback(popupLogin)).resolves.toBeUndefined()
+    expect(popupLogin).toHaveBeenCalledTimes(1)
+    expect(authService.reloadUserFromStorage).not.toHaveBeenCalled()
+  })
+
+  it('resolves via BroadcastChannel when a COOP completion arrives after popup rejection', async () => {
+    vi.useFakeTimers()
+    const popupLogin = vi.fn().mockRejectedValue(new Error('popup blocked'))
+
+    const loginPromise = loginWithPopupCoopFallback(popupLogin)
+
+    const bc = new BroadcastChannel('oc_oidc_popup_complete')
+    bc.postMessage({ type: 'complete' })
+    bc.close()
+
+    await expect(loginPromise).resolves.toBeUndefined()
+    expect(authService.reloadUserFromStorage).toHaveBeenCalledTimes(1)
+  })
+
+  it('rejects after the grace period when the popup is blocked and no completion arrives', async () => {
+    vi.useFakeTimers()
+    const error = new Error('popup blocked')
+    const popupLogin = vi.fn().mockRejectedValue(error)
+
+    const loginPromise = loginWithPopupCoopFallback(popupLogin)
+    const expectation = expect(loginPromise).rejects.toBe(error)
+
+    await vi.advanceTimersByTimeAsync(2_000)
+
+    await expectation
+    expect(authService.reloadUserFromStorage).not.toHaveBeenCalled()
+  })
+})

--- a/packages/web-runtime/tests/unit/pages/__snapshots__/accessDenied.spec.ts.snap
+++ b/packages/web-runtime/tests/unit/pages/__snapshots__/accessDenied.spec.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`access denied page > renders component 1`] = `
 "<div class="oc-height-viewport oc-flex oc-flex-column oc-flex-center oc-flex-middle">
-  <div class="oc-login-card"><img class="oc-login-logo" src="themes/owncloud/assets/logo.svg" alt="" aria-hidden="true">
+  <div class="oc-login-card"><a attrs="[object Object]" aria-label="Home"></a>
     <div class="oc-login-card-body oc-width-medium">
       <h2 class="oc-login-card-title">Not logged in</h2>
       <p>This could be because of a routine safety log out, or because your account is either inactive or not yet authorized for use. Please try logging in after a while or seek help from your Administrator.</p>

--- a/packages/web-runtime/tests/unit/pages/oidcCallback.spec.ts
+++ b/packages/web-runtime/tests/unit/pages/oidcCallback.spec.ts
@@ -8,12 +8,14 @@ import oidcCallback from '../../../src/pages/oidcCallback.vue'
 import { authService } from '../../../src/services/auth'
 import { mock } from 'vitest-mock-extended'
 import { computed } from 'vue'
+import { flushPromises } from '@vue/test-utils'
+import { useRoute } from '@ownclouders/web-pkg'
 
 const mockUseEmbedMode = vi.fn()
 
 vi.mock('@ownclouders/web-pkg', async (importOriginal) => ({
   ...(await importOriginal<any>()),
-  useRoute: vi.fn().mockReturnValue({ query: {} }),
+  useRoute: vi.fn().mockReturnValue({ path: '/web-oidc-callback', query: {} }),
   useEmbedMode: vi.fn().mockImplementation(() => mockUseEmbedMode())
 }))
 
@@ -118,6 +120,52 @@ describe('oidcCallback page', () => {
 
       expect(signInCallbackSpy).not.toHaveBeenCalled()
     })
+  })
+})
+
+describe('popup callback (/web-oidc-popup-callback)', () => {
+  beforeEach(() => {
+    mockUseEmbedMode.mockReturnValue({
+      isDelegatingAuthentication: computed(() => false),
+      verifyDelegatedAuthenticationOrigin: vi.fn().mockReturnValue(true)
+    })
+  })
+
+  it('calls signInPopupCallback when on popup callback route', async () => {
+    vi.mocked(useRoute).mockReturnValue({ path: '/web-oidc-popup-callback', query: {} } as any)
+    const spy = vi.spyOn(authService, 'signInPopupCallback').mockResolvedValue()
+    getWrapper()
+    await flushPromises()
+    expect(spy).toHaveBeenCalled()
+  })
+
+  it('triggers COOP fallback when signInPopupCallback fails with "window.opener"', async () => {
+    vi.mocked(useRoute).mockReturnValue({ path: '/web-oidc-popup-callback', query: {} } as any)
+    vi.spyOn(authService, 'signInPopupCallback').mockRejectedValue(
+      new Error("No window.opener. Can't complete notification.")
+    )
+    const fallbackSpy = vi
+      .spyOn(authService, 'signInCallbackForCOOPFallback')
+      .mockResolvedValue()
+    const closeSpy = vi.spyOn(window, 'close').mockImplementation(() => {})
+
+    getWrapper()
+    await flushPromises()
+
+    expect(fallbackSpy).toHaveBeenCalled()
+    expect(closeSpy).toHaveBeenCalled()
+  })
+
+  it('shows error when signInPopupCallback fails with unrelated error', async () => {
+    vi.mocked(useRoute).mockReturnValue({ path: '/web-oidc-popup-callback', query: {} } as any)
+    vi.spyOn(authService, 'signInPopupCallback').mockRejectedValue(new Error('some other error'))
+    vi.spyOn(authService, 'signInCallbackForCOOPFallback').mockResolvedValue()
+
+    const { wrapper } = getWrapper()
+    await flushPromises()
+
+    // Popup path shows the minimal page; error span should be visible
+    expect(wrapper.find('.popup-callback').text()).toContain('Authentication failed')
   })
 })
 

--- a/packages/web-runtime/tests/unit/services/auth/authService.spec.ts
+++ b/packages/web-runtime/tests/unit/services/auth/authService.spec.ts
@@ -177,6 +177,41 @@ describe('AuthService', () => {
     })
   })
 
+  describe('handleAuthError', () => {
+    it('routes startup failures to accessDenied with loginError reason', async () => {
+      const authService = new AuthService()
+      const router = createRouter({
+        routes: [{ path: '/access-denied', name: 'accessDenied', component: { template: '<div />' } }]
+      })
+      const pushSpy = vi.spyOn(router, 'push')
+
+      initAuthService({ authService, router })
+      const authStore = useAuthStore()
+      authStore.userContextReady = false
+
+      await authService.handleAuthError(mock<RouteLocation>({ name: 'files' }))
+
+      expect(pushSpy).toHaveBeenCalledWith({
+        name: 'accessDenied',
+        query: { reason: 'loginError' }
+      })
+    })
+
+    it('shows session expired modal for mid-session failures', async () => {
+      const authService = new AuthService()
+      const router = createRouter()
+
+      initAuthService({ authService, router })
+      const authStore = useAuthStore()
+      authStore.userContextReady = true
+
+      await authService.handleAuthError(mock<RouteLocation>({ name: 'files' }))
+
+      // createTestingPinia stubs actions, so assert the action was invoked
+      expect(authStore.setSessionExpired).toHaveBeenCalledWith(true)
+    })
+  })
+
   describe('reloadUserFromStorage', () => {
     it('reads user from storage and calls updateContext', async () => {
       const authService = new AuthService()

--- a/packages/web-runtime/tests/unit/services/auth/authService.spec.ts
+++ b/packages/web-runtime/tests/unit/services/auth/authService.spec.ts
@@ -153,4 +153,61 @@ describe('AuthService', () => {
       expect(mockUpdateContext).toHaveBeenCalledWith('access-token', true)
     })
   })
+
+  describe('signInCallbackForCOOPFallback', () => {
+    it('processes redirect callback and broadcasts completion', async () => {
+      const authService = new AuthService()
+      const signinRedirectCallbackMock = vi.fn().mockResolvedValue(undefined)
+
+      Object.defineProperty(authService, 'userManager', {
+        value: mock<UserManager>({ signinRedirectCallback: signinRedirectCallbackMock })
+      })
+
+      const broadcastMock = { postMessage: vi.fn(), close: vi.fn() }
+      vi.stubGlobal('BroadcastChannel', vi.fn(() => broadcastMock))
+
+      initAuthService({ authService })
+      await authService.signInCallbackForCOOPFallback()
+
+      expect(signinRedirectCallbackMock).toHaveBeenCalledWith(window.location.href)
+      expect(broadcastMock.postMessage).toHaveBeenCalledWith({ type: 'complete' })
+      expect(broadcastMock.close).toHaveBeenCalled()
+
+      vi.unstubAllGlobals()
+    })
+  })
+
+  describe('reloadUserFromStorage', () => {
+    it('reads user from storage and calls updateContext', async () => {
+      const authService = new AuthService()
+
+      Object.defineProperty(authService, 'userManager', {
+        value: mock<UserManager>({
+          getUser: vi.fn().mockResolvedValue({ access_token: 'new-token' }),
+          updateContext: mockUpdateContext
+        })
+      })
+
+      initAuthService({ authService })
+      await authService.reloadUserFromStorage()
+
+      expect(mockUpdateContext).toHaveBeenCalledWith('new-token', true)
+    })
+
+    it('does nothing when no user in storage', async () => {
+      const authService = new AuthService()
+
+      Object.defineProperty(authService, 'userManager', {
+        value: mock<UserManager>({
+          getUser: vi.fn().mockResolvedValue(null),
+          updateContext: mockUpdateContext
+        })
+      })
+
+      initAuthService({ authService })
+      await authService.reloadUserFromStorage()
+
+      expect(mockUpdateContext).not.toHaveBeenCalled()
+    })
+  })
 })


### PR DESCRIPTION
Attempt to change the auth workflow so that users are no longer redirected from the current page, they see a modal box saying that they are disconnected.

This is to ensure we stop losing any context due to redirections.

When disconnected, users are able to re-login via a pop-up. This should unblock all open tabs.

Its worked started on the first iteration from Rodrigo to bring pop-up auth for when web gets embedded (future implementation of the file picker).