### PR TITLE
Widen spacesState mock type to match spaces store

### DIFF
--- a/packages/web-test-helpers/src/mocks/pinia.ts
+++ b/packages/web-test-helpers/src/mocks/pinia.ts
@@ -72,7 +72,13 @@ export type PiniaMockOptions = {
     graphRoles?: Record<string, ShareRole>
     loading?: boolean
   }
-  spacesState?: { spaces?: SpaceResource[]; currentSpace?: SpaceResource }
+  spacesState?: {
+    spaces?: SpaceResource[]
+    currentSpace?: SpaceResource
+    spacesInitialized?: boolean
+    mountPointsInitialized?: boolean
+    spacesLoading?: boolean
+  }
   userState?: { user?: User }
   capabilityState?: {
     capabilities?: Partial<Capabilities['capabilities']>


### PR DESCRIPTION
## Summary

PR #247 added loading-state tests to `DriveRedirect.spec.ts` that pass `spacesInitialized` and `spacesLoading` through the shared Pinia mock helper. However, the `PiniaMockOptions.spacesState` type in `packages/web-test-helpers/src/mocks/pinia.ts` only declared `spaces` and `currentSpace`, so `vue-tsc` rejected the extra properties with TS2353, breaking the type-check build after #247 merged.

This widens the `spacesState` mock type to match the real `spaces` Pinia store, which exposes `spacesInitialized`, `mountPointsInitialized`, and `spacesLoading` in addition to `spaces` and `currentSpace`. At runtime these values were already handled correctly (spread into `initialState.spaces`); only the type definition was out of date.

## Changes

- Extend `PiniaMockOptions.spacesState` with optional `spacesInitialized`, `mountPointsInitialized`, and `spacesLoading` fields.

## Test plan

- [x] `pnpm exec vitest run packages/web-app-files/tests/unit/views/spaces/DriveRedirect.spec.ts` passes (2/2).
- [x] `pnpm check:types` no longer reports the TS2353 error on `DriveRedirect.spec.ts` / `spacesState`.
- [x] CI type-check and unit tests are green.


