### PR TITLE
Simplified information text for the links

### DIFF
--- a/packages/design-system/src/components/OcContextualHelper/OcContextualHelper.vue
+++ b/packages/design-system/src/components/OcContextualHelper/OcContextualHelper.vue
@@ -123,7 +123,7 @@ export default {
           {text: "Only invited people can access", headline: true},
           {text: "Only people from the list \"Invited people\" can access. If there is no list, no people are invited yet."},
           {text: "Everyone with the link", headline: true },
-          {text: "Everyone with the link can access. Note: If you share this link with people from the list \"Invited people\", they need to login-in so that their individual assigned permissions can take effect. If they are not logged-in, the permissions of the link take effect." }
+          {text: "Everyone with the link can access, no login required. Open it to provide users with direct paths if needed. Users in the \"Invited people\" list should use the Direct link instead." }
         ],
         endText: "Invited persons can not see who else has access",
         readMoreLink: "https://owncloud.design"

--- a/packages/design-system/src/components/OcInfoDrop/OcInfoDrop.vue
+++ b/packages/design-system/src/components/OcInfoDrop/OcInfoDrop.vue
@@ -239,7 +239,7 @@ export default {
           {text: "Only invited people can access", headline: true},
           {text: "Only people from the list \"Invited people\" can access. If there is no list, no people are invited yet."},
           {text: "Everyone with the link", headline: true },
-          {text: "Everyone with the link can access. Note: If you share this link with people from the list \"Invited people\", they need to login-in so that their individual assigned permissions can take effect. If they are not logged-in, the permissions of the link take effect." }
+          {text: "Everyone with the link can access, no login required. Open it to provide users with direct paths if needed. Users in the \"Invited people\" list should use the Direct link instead." }
         ],
         endText: "Invited persons can not see who else has access",
         readMoreLink: "https://owncloud.design"


### PR DESCRIPTION
This is a textual change, no logic involved. It comes from user feedback: the text is now shorter and more up to date (we have "direct links").