### PR TITLE
Show dedicated sign-in blocked page for linked-primary account HTTP 409

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,9 @@ tests/report/cucumber_report.html
 # third party licenses
 /third-party-licenses
 
+# Local files (keep in repo root on any branch; do not commit)
+LOCAL_*
+
 # dev setup
 /dev/docker/ocis-ca
 /dev/docker/traefik/certificates

--- a/packages/web-pkg/src/composables/authContext/useAuthService.ts
+++ b/packages/web-pkg/src/composables/authContext/useAuthService.ts
@@ -2,7 +2,7 @@ import { useService } from '../service'
 import { NavigationFailure } from 'vue-router'
 
 export interface AuthServiceInterface {
-  handleAuthError(route: any, options?: { forceLogout?: boolean }): any
+  handleAuthError(route: any, options?: { forceLogout?: boolean; cause?: unknown }): any
   signinSilent(): Promise<unknown>
   logoutUser(): Promise<void | NavigationFailure>
   getRefreshToken(): Promise<string>

--- a/packages/web-pkg/src/composables/piniaStores/config/types.ts
+++ b/packages/web-pkg/src/composables/piniaStores/config/types.ts
@@ -128,7 +128,13 @@ const OptionsConfigSchema = z.object({
   hideNavigation: z.boolean().optional(),
   defaultLanguage: z.string().optional(),
   listVersions: z.boolean().optional(),
-  alertRwFolders: z.record(z.string()).optional()
+  alertRwFolders: z.record(z.string()).optional(),
+  linkedAccount: z
+    .object({
+      docUrl: z.string().optional(),
+      userPortalUrl: z.string().optional()
+    })
+    .optional()
 })
 
 export type OptionsConfig = z.infer<typeof OptionsConfigSchema>

--- a/packages/web-pkg/src/helpers/auth/index.ts
+++ b/packages/web-pkg/src/helpers/auth/index.ts
@@ -1,0 +1,1 @@
+export * from './linkedPrimaryAccountError'

--- a/packages/web-pkg/src/helpers/auth/linkedPrimaryAccountError.ts
+++ b/packages/web-pkg/src/helpers/auth/linkedPrimaryAccountError.ts
@@ -1,6 +1,12 @@
 import axios, { AxiosError, AxiosInstance, AxiosResponse } from 'axios'
 
 /**
+ * Detects Reva's linked-primary sign-in contract: HTTP 409 with header
+ * `X-Oc-Linked-Primary-Account: true` and/or `error.code` `linkedPrimaryAccount`
+ * (see Reva `identity-auth-http-errors` documentation).
+ */
+
+/**
  * Machine-readable codes backends may return for "linked primary account"
  * conflicts. These are trusted enough to use on authenticated protected endpoints.
  */
@@ -118,7 +124,23 @@ export function wasLinkedPrimaryAuthHandled(error: unknown): boolean {
 }
 
 /**
- * Registers an Axios response interceptor: linked-primary 409 on bootstrap URLs invokes `onDetected`, then marks the error so duplicate `handleAuthError(..., { cause })` calls no-op.
+ * Axios response error handler: runs `onDetected` for linked-primary 409s and marks the
+ * error so duplicate `handleAuthError(..., { cause })` calls no-op.
+ */
+export function createLinkedPrimaryRejectionHandler(
+  onDetected: (error: unknown) => void | Promise<void>
+): (error: unknown) => Promise<unknown> {
+  return async (error: unknown) => {
+    if (isLinkedPrimaryAccountError(error)) {
+      await onDetected(error)
+      markLinkedPrimaryAuthHandled(error)
+    }
+    return Promise.reject(error)
+  }
+}
+
+/**
+ * Registers an Axios response interceptor for linked-primary 409 responses.
  */
 export function attachLinkedPrimaryAccountResponseInterceptor(
   axiosInstance: AxiosInstance,
@@ -126,13 +148,7 @@ export function attachLinkedPrimaryAccountResponseInterceptor(
 ): number {
   return axiosInstance.interceptors.response.use(
     (response) => response,
-    async (error: unknown) => {
-      if (isLinkedPrimaryAccountError(error)) {
-        await onDetected(error)
-        markLinkedPrimaryAuthHandled(error)
-      }
-      return Promise.reject(error)
-    }
+    createLinkedPrimaryRejectionHandler(onDetected)
   )
 }
 

--- a/packages/web-pkg/src/helpers/auth/linkedPrimaryAccountError.ts
+++ b/packages/web-pkg/src/helpers/auth/linkedPrimaryAccountError.ts
@@ -1,16 +1,8 @@
 import axios, { AxiosError, AxiosInstance, AxiosResponse } from 'axios'
 
 /**
- * LOCAL 4348: Linked primary account detection on identity bootstrap routes only for matching HTTP responses.
- *
- * Post-bootstrap behaviour relies on Axios response interceptors wired from runtime (`ClientService.attachLinkedPrimaryAccountHandling`)
- * on Graph, OCS, and authenticated HTTP stacks only. WebDAV and other non-Axios transports are out of scope unless backends expose the same Axios-shaped errors there.
- */
-
-/**
  * Machine-readable codes backends may return for "linked primary account"
- * on identity bootstrap routes (Graph `/me`, settings, OCS user/capabilities).
- * Align error payloads with your deployment; do not treat arbitrary 409 as this case.
+ * conflicts. These are trusted enough to use on authenticated protected endpoints.
  */
 const LINKED_PRIMARY_ERROR_CODES = new Set([
   'linkedPrimaryAccount',
@@ -112,14 +104,17 @@ export function markLinkedPrimaryAuthHandled(error: unknown): void {
   if (!axios.isAxiosError(error) || !error.config) {
     return
   }
-  ;(error.config as unknown as Record<string, unknown>)[LINKED_PRIMARY_AUTH_HANDLED_CONFIG_KEY] = true
+  ;(error.config as unknown as Record<string, unknown>)[LINKED_PRIMARY_AUTH_HANDLED_CONFIG_KEY] =
+    true
 }
 
 export function wasLinkedPrimaryAuthHandled(error: unknown): boolean {
   if (!axios.isAxiosError(error) || !error.config) {
     return false
   }
-  return !!(error.config as unknown as Record<string, unknown>)[LINKED_PRIMARY_AUTH_HANDLED_CONFIG_KEY]
+  return !!(error.config as unknown as Record<string, unknown>)[
+    LINKED_PRIMARY_AUTH_HANDLED_CONFIG_KEY
+  ]
 }
 
 /**
@@ -142,8 +137,8 @@ export function attachLinkedPrimaryAccountResponseInterceptor(
 }
 
 /**
- * True when the response matches the linked-primary contract on an identity
- * bootstrap URL (so unrelated WebDAV or editor 409s are excluded).
+ * True when a protected Axios response matches the linked-primary contract.
+ * Header and code are trusted signals; message matching stays limited to bootstrap URLs.
  */
 export function isLinkedPrimaryAccountError(err: unknown): boolean {
   if (!axios.isAxiosError(err)) {
@@ -154,9 +149,6 @@ export function isLinkedPrimaryAccountError(err: unknown): boolean {
     return false
   }
   const path = resolveRequestPath(ae.config)
-  if (!isIdentityBootstrapRequestUrl(path)) {
-    return false
-  }
   if (readLinkedPrimaryHeader(ae.response.headers)) {
     return true
   }
@@ -164,5 +156,5 @@ export function isLinkedPrimaryAccountError(err: unknown): boolean {
   if (code && LINKED_PRIMARY_ERROR_CODES.has(code)) {
     return true
   }
-  return messageSuggestsLinkedPrimary(ae.response.data)
+  return isIdentityBootstrapRequestUrl(path) && messageSuggestsLinkedPrimary(ae.response.data)
 }

--- a/packages/web-pkg/src/helpers/auth/linkedPrimaryAccountError.ts
+++ b/packages/web-pkg/src/helpers/auth/linkedPrimaryAccountError.ts
@@ -1,0 +1,168 @@
+import axios, { AxiosError, AxiosInstance, AxiosResponse } from 'axios'
+
+/**
+ * LOCAL 4348: Linked primary account detection on identity bootstrap routes only for matching HTTP responses.
+ *
+ * Post-bootstrap behaviour relies on Axios response interceptors wired from runtime (`ClientService.attachLinkedPrimaryAccountHandling`)
+ * on Graph, OCS, and authenticated HTTP stacks only. WebDAV and other non-Axios transports are out of scope unless backends expose the same Axios-shaped errors there.
+ */
+
+/**
+ * Machine-readable codes backends may return for "linked primary account"
+ * on identity bootstrap routes (Graph `/me`, settings, OCS user/capabilities).
+ * Align error payloads with your deployment; do not treat arbitrary 409 as this case.
+ */
+const LINKED_PRIMARY_ERROR_CODES = new Set([
+  'linkedPrimaryAccount',
+  'LinkedPrimaryAccount',
+  'identity.LinkedPrimaryAccount',
+  'Identity.LinkedPrimaryAccount',
+  'notAllowedLinkedPrimaryAccount'
+])
+
+const LINKED_PRIMARY_HEADER = 'x-oc-linked-primary-account'
+
+/** Last resort only; prefer `error.code` or `X-Oc-Linked-Primary-Account` header from backend. */
+const MESSAGE_FRAGMENTS = ['linked primary account', 'linked primary']
+
+export const LINKED_PRIMARY_AUTH_HANDLED_CONFIG_KEY = 'linkedPrimaryAuthHandled'
+
+function resolveRequestPath(config: AxiosError['config']): string {
+  if (!config?.url) {
+    return ''
+  }
+  try {
+    const base = config.baseURL || 'http://localhost'
+    return new URL(config.url, base).pathname.toLowerCase()
+  } catch {
+    return config.url.split('?')[0].toLowerCase()
+  }
+}
+
+export function isIdentityBootstrapRequestUrl(pathOrFullUrl: string): boolean {
+  const path = pathOrFullUrl.toLowerCase()
+  return (
+    path.includes('/graph/v1.0/me') ||
+    path.includes('/graph/v1beta/me') ||
+    path.includes('/graph/v1beta1/me') ||
+    path.includes('/api/v0/settings/') ||
+    path.includes('/ocs/v1.php/cloud/capabilities') ||
+    path.includes('/ocs/v1.php/cloud/users/') ||
+    path.endsWith('/ocs/v1.php/cloud/user')
+  )
+}
+
+function readGraphStyleErrorCode(data: unknown): string | undefined {
+  if (!data || typeof data !== 'object') {
+    return undefined
+  }
+  const root = data as Record<string, unknown>
+  const err = root.error
+  if (err && typeof err === 'object' && 'code' in err) {
+    const code = (err as { code?: unknown }).code
+    return typeof code === 'string' ? code : undefined
+  }
+  return undefined
+}
+
+function readLinkedPrimaryHeader(headers: AxiosResponse['headers']): boolean {
+  if (!headers) {
+    return false
+  }
+  let raw: string | undefined
+  if (typeof (headers as { get?: (n: string) => unknown }).get === 'function') {
+    const get = (headers as { get: (n: string) => unknown }).get
+    raw = get(LINKED_PRIMARY_HEADER) as string | undefined
+    if (raw === undefined || raw === '') {
+      raw = get('X-Oc-Linked-Primary-Account') as string | undefined
+    }
+  } else {
+    const h = headers as Record<string, string | undefined>
+    raw =
+      h[LINKED_PRIMARY_HEADER] ??
+      h['X-Oc-Linked-Primary-Account'] ??
+      h['x-oc-linked-primary-account']
+  }
+  return raw !== undefined && String(raw).toLowerCase() === 'true'
+}
+
+function messageSuggestsLinkedPrimary(data: unknown): boolean {
+  const msg = readGraphStyleMessage(data)
+  if (!msg) {
+    return false
+  }
+  const lower = msg.toLowerCase()
+  return MESSAGE_FRAGMENTS.some((f) => lower.includes(f))
+}
+
+function readGraphStyleMessage(data: unknown): string | undefined {
+  if (!data || typeof data !== 'object') {
+    return undefined
+  }
+  const root = data as Record<string, unknown>
+  const err = root.error
+  if (err && typeof err === 'object' && 'message' in err) {
+    const message = (err as { message?: unknown }).message
+    return typeof message === 'string' ? message : undefined
+  }
+  return undefined
+}
+
+export function markLinkedPrimaryAuthHandled(error: unknown): void {
+  if (!axios.isAxiosError(error) || !error.config) {
+    return
+  }
+  ;(error.config as unknown as Record<string, unknown>)[LINKED_PRIMARY_AUTH_HANDLED_CONFIG_KEY] = true
+}
+
+export function wasLinkedPrimaryAuthHandled(error: unknown): boolean {
+  if (!axios.isAxiosError(error) || !error.config) {
+    return false
+  }
+  return !!(error.config as unknown as Record<string, unknown>)[LINKED_PRIMARY_AUTH_HANDLED_CONFIG_KEY]
+}
+
+/**
+ * Registers an Axios response interceptor: linked-primary 409 on bootstrap URLs invokes `onDetected`, then marks the error so duplicate `handleAuthError(..., { cause })` calls no-op.
+ */
+export function attachLinkedPrimaryAccountResponseInterceptor(
+  axiosInstance: AxiosInstance,
+  onDetected: (error: unknown) => void | Promise<void>
+): number {
+  return axiosInstance.interceptors.response.use(
+    (response) => response,
+    async (error: unknown) => {
+      if (isLinkedPrimaryAccountError(error)) {
+        await onDetected(error)
+        markLinkedPrimaryAuthHandled(error)
+      }
+      return Promise.reject(error)
+    }
+  )
+}
+
+/**
+ * True when the response matches the linked-primary contract on an identity
+ * bootstrap URL (so unrelated WebDAV or editor 409s are excluded).
+ */
+export function isLinkedPrimaryAccountError(err: unknown): boolean {
+  if (!axios.isAxiosError(err)) {
+    return false
+  }
+  const ae = err as AxiosError
+  if (ae.response?.status !== 409) {
+    return false
+  }
+  const path = resolveRequestPath(ae.config)
+  if (!isIdentityBootstrapRequestUrl(path)) {
+    return false
+  }
+  if (readLinkedPrimaryHeader(ae.response.headers)) {
+    return true
+  }
+  const code = readGraphStyleErrorCode(ae.response.data)
+  if (code && LINKED_PRIMARY_ERROR_CODES.has(code)) {
+    return true
+  }
+  return messageSuggestsLinkedPrimary(ae.response.data)
+}

--- a/packages/web-pkg/src/helpers/index.ts
+++ b/packages/web-pkg/src/helpers/index.ts
@@ -1,3 +1,4 @@
+export * from './auth'
 export * from './cache'
 export * from './folderLink'
 export * from './resource'

--- a/packages/web-pkg/src/http/client.ts
+++ b/packages/web-pkg/src/http/client.ts
@@ -32,6 +32,12 @@ export class HttpClient {
     this.cancelToken.cancel(msg)
   }
 
+  public useResponseErrorInterceptor(
+    onRejected: (error: unknown) => unknown | Promise<unknown>
+  ): number {
+    return this.instance.interceptors.response.use(undefined, onRejected)
+  }
+
   public async delete<T = any, D = any, S extends z.Schema | T = T>(
     url: string,
     data?: D,

--- a/packages/web-pkg/src/services/client/client.ts
+++ b/packages/web-pkg/src/services/client/client.ts
@@ -10,6 +10,12 @@ import { Language } from 'vue3-gettext'
 import { FetchEventSourceInit } from '@microsoft/fetch-event-source'
 import { sse } from '@ownclouders/web-client/sse'
 import { AuthStore, ConfigStore } from '../../composables'
+import type { AxiosInstance } from 'axios'
+import {
+  attachLinkedPrimaryAccountResponseInterceptor,
+  isLinkedPrimaryAccountError,
+  markLinkedPrimaryAuthHandled
+} from '../../helpers/auth/linkedPrimaryAccountError'
 
 const createFetchOptions = (authParams: AuthParameters, language: string): FetchEventSourceInit => {
   return {
@@ -39,6 +45,9 @@ export class ClientService {
   private graphClient: Graph
   private ocsClient: OCS
   private webDavClient: WebDAV
+  private graphAxios: AxiosInstance | null = null
+  private ocsAxios: AxiosInstance | null = null
+  private linkedPrimaryInterceptorsAttached = false
 
   public initiatorId = uuidV4()
 
@@ -109,12 +118,41 @@ export class ClientService {
     return this.webDavClient
   }
 
+  /**
+   * Registers linked-primary 409 handling on Graph, OCS, and authenticated HTTP Axios stacks (LOCAL 4348 §4.2).
+   * Safe to call once after runtime wires AuthService.
+   */
+  public attachLinkedPrimaryAccountHandling(
+    handler: (error: unknown) => void | Promise<void>
+  ): void {
+    if (this.linkedPrimaryInterceptorsAttached) {
+      return
+    }
+    this.linkedPrimaryInterceptorsAttached = true
+
+    if (this.graphAxios) {
+      attachLinkedPrimaryAccountResponseInterceptor(this.graphAxios, handler)
+    }
+    if (this.ocsAxios) {
+      attachLinkedPrimaryAccountResponseInterceptor(this.ocsAxios, handler)
+    }
+
+    this.httpAuthenticatedClient.useResponseErrorInterceptor(async (error: unknown) => {
+      if (isLinkedPrimaryAccountError(error)) {
+        await handler(error)
+        markLinkedPrimaryAuthHandled(error)
+      }
+      return Promise.reject(error)
+    })
+  }
+
   get currentLanguage() {
     return this.language.current
   }
 
   private initGraphClient() {
     const axiosClient = axios.create({ headers: this.staticHeaders })
+    this.graphAxios = axiosClient
     axiosClient.interceptors.request.use((config) => {
       Object.assign(config.headers, this.getDynamicHeaders())
       return config
@@ -124,6 +162,7 @@ export class ClientService {
 
   private initOcsClient() {
     const axiosClient = axios.create({ headers: this.staticHeaders })
+    this.ocsAxios = axiosClient
     axiosClient.interceptors.request.use((config) => {
       Object.assign(config.headers, this.getDynamicHeaders())
       return config

--- a/packages/web-pkg/src/services/client/client.ts
+++ b/packages/web-pkg/src/services/client/client.ts
@@ -13,8 +13,7 @@ import { AuthStore, ConfigStore } from '../../composables'
 import type { AxiosInstance } from 'axios'
 import {
   attachLinkedPrimaryAccountResponseInterceptor,
-  isLinkedPrimaryAccountError,
-  markLinkedPrimaryAuthHandled
+  createLinkedPrimaryRejectionHandler
 } from '../../helpers/auth/linkedPrimaryAccountError'
 
 const createFetchOptions = (authParams: AuthParameters, language: string): FetchEventSourceInit => {
@@ -119,7 +118,7 @@ export class ClientService {
   }
 
   /**
-   * Registers linked-primary 409 handling on Graph, OCS, and authenticated HTTP Axios stacks (LOCAL 4348 §4.2).
+   * Registers linked-primary 409 handling on Graph, OCS, and authenticated HTTP clients.
    * Safe to call once after runtime wires AuthService.
    */
   public attachLinkedPrimaryAccountHandling(
@@ -137,13 +136,9 @@ export class ClientService {
       attachLinkedPrimaryAccountResponseInterceptor(this.ocsAxios, handler)
     }
 
-    this.httpAuthenticatedClient.useResponseErrorInterceptor(async (error: unknown) => {
-      if (isLinkedPrimaryAccountError(error)) {
-        await handler(error)
-        markLinkedPrimaryAuthHandled(error)
-      }
-      return Promise.reject(error)
-    })
+    this.httpAuthenticatedClient.useResponseErrorInterceptor(
+      createLinkedPrimaryRejectionHandler(handler)
+    )
   }
 
   get currentLanguage() {

--- a/packages/web-pkg/tests/unit/helpers/auth/linkedPrimaryAccountError.spec.ts
+++ b/packages/web-pkg/tests/unit/helpers/auth/linkedPrimaryAccountError.spec.ts
@@ -2,6 +2,7 @@ import axios, { AxiosError, InternalAxiosRequestConfig } from 'axios'
 import { describe, expect, it, vi } from 'vitest'
 import {
   attachLinkedPrimaryAccountResponseInterceptor,
+  createLinkedPrimaryRejectionHandler,
   isLinkedPrimaryAccountError,
   markLinkedPrimaryAuthHandled,
   wasLinkedPrimaryAuthHandled
@@ -150,6 +151,19 @@ describe('linkedPrimaryAuthHandled marker', () => {
     expect(wasLinkedPrimaryAuthHandled(error)).toBe(false)
     markLinkedPrimaryAuthHandled(error)
     expect(wasLinkedPrimaryAuthHandled(error)).toBe(true)
+  })
+})
+
+describe('createLinkedPrimaryRejectionHandler', () => {
+  it('invokes onDetected and marks handled for linked-primary errors', async () => {
+    const handler = vi.fn().mockResolvedValue(undefined)
+    const onRejected = createLinkedPrimaryRejectionHandler(handler)
+    const rejection = err409({})
+
+    await expect(onRejected(rejection)).rejects.toBe(rejection)
+
+    expect(handler).toHaveBeenCalledTimes(1)
+    expect(wasLinkedPrimaryAuthHandled(rejection)).toBe(true)
   })
 })
 

--- a/packages/web-pkg/tests/unit/helpers/auth/linkedPrimaryAccountError.spec.ts
+++ b/packages/web-pkg/tests/unit/helpers/auth/linkedPrimaryAccountError.spec.ts
@@ -1,0 +1,161 @@
+import axios, { AxiosError, InternalAxiosRequestConfig } from 'axios'
+import { describe, expect, it, vi } from 'vitest'
+import {
+  attachLinkedPrimaryAccountResponseInterceptor,
+  isLinkedPrimaryAccountError,
+  markLinkedPrimaryAuthHandled,
+  wasLinkedPrimaryAuthHandled
+} from '../../../../src/helpers/auth/linkedPrimaryAccountError'
+
+function err409(options: {
+  url?: string
+  baseURL?: string
+  data?: unknown
+  headers?: Record<string, string>
+}): AxiosError {
+  return new AxiosError(
+    'conflict',
+    'ERR_BAD_REQUEST',
+    {
+      url: options.url ?? '/graph/v1.0/me',
+      baseURL: options.baseURL ?? 'https://example.com/',
+      headers: {}
+    } as InternalAxiosRequestConfig,
+    {},
+    {
+      status: 409,
+      statusText: 'Conflict',
+      data: options.data ?? { error: { code: 'linkedPrimaryAccount', message: 'x' } },
+      headers: options.headers ?? {},
+      config: {} as AxiosError['config']
+    }
+  )
+}
+
+describe('isLinkedPrimaryAccountError', () => {
+  it('returns false for non-axios errors', () => {
+    expect(isLinkedPrimaryAccountError(new Error('oops'))).toBe(false)
+  })
+
+  it('returns false for 409 on non-bootstrap URLs', () => {
+    const error = err409({
+      url: '/remote.php/dav/files/foo',
+      data: { error: { code: 'linkedPrimaryAccount' } }
+    })
+    expect(isLinkedPrimaryAccountError(error)).toBe(false)
+  })
+
+  it('returns false for bootstrap URL with 409 and body that does not match contract', () => {
+    const emptyBody = err409({
+      data: {}
+    })
+    expect(isLinkedPrimaryAccountError(emptyBody)).toBe(false)
+
+    const otherCode = err409({
+      data: { error: { code: 'generalException', message: 'something unrelated' } }
+    })
+    expect(isLinkedPrimaryAccountError(otherCode)).toBe(false)
+  })
+
+  it('returns true for 409 on Graph /me with documented error code', () => {
+    expect(isLinkedPrimaryAccountError(err409({}))).toBe(true)
+  })
+
+  it('returns true when response sets X-Oc-Linked-Primary-Account header', () => {
+    const error = err409({
+      data: {},
+      headers: { 'x-oc-linked-primary-account': 'true' }
+    })
+    expect(isLinkedPrimaryAccountError(error)).toBe(true)
+  })
+
+  it('returns true for settings API path with matching code', () => {
+    const error = err409({
+      url: '/api/v0/settings/roles-list',
+      data: { error: { code: 'identity.LinkedPrimaryAccount' } }
+    })
+    expect(isLinkedPrimaryAccountError(error)).toBe(true)
+  })
+
+  it('returns true for OCS user-capabilities style path with matching code', () => {
+    const error = err409({
+      url: '/ocs/v1.php/cloud/users/account-id',
+      data: { error: { code: 'linkedPrimaryAccount' } }
+    })
+    expect(isLinkedPrimaryAccountError(error)).toBe(true)
+  })
+
+  it('returns true for Graph v1beta1 /me with matching code', () => {
+    const error = err409({
+      url: '/graph/v1beta1/me',
+      data: { error: { code: 'linkedPrimaryAccount' } }
+    })
+    expect(isLinkedPrimaryAccountError(error)).toBe(true)
+  })
+
+  it('returns true for singular cloud/user endpoint path with matching code', () => {
+    const error = err409({
+      url: '/ocs/v1.php/cloud/user',
+      data: { error: { code: 'linkedPrimaryAccount' } }
+    })
+    expect(isLinkedPrimaryAccountError(error)).toBe(true)
+  })
+
+  it('returns true when only error.message suggests linked primary on bootstrap URL', () => {
+    const error = err409({
+      data: {
+        error: {
+          code: 'unknown',
+          message: 'Your linked primary account cannot access this application'
+        }
+      }
+    })
+    expect(isLinkedPrimaryAccountError(error)).toBe(true)
+  })
+})
+
+describe('linkedPrimaryAuthHandled marker', () => {
+  it('markLinkedPrimaryAuthHandled sets flag readable by wasLinkedPrimaryAuthHandled', () => {
+    const error = err409({})
+    expect(wasLinkedPrimaryAuthHandled(error)).toBe(false)
+    markLinkedPrimaryAuthHandled(error)
+    expect(wasLinkedPrimaryAuthHandled(error)).toBe(true)
+  })
+})
+
+describe('attachLinkedPrimaryAccountResponseInterceptor', () => {
+  it('registers a response interceptor that invokes onDetected then marks handled', async () => {
+    const handler = vi.fn().mockResolvedValue(undefined)
+    const client = axios.create()
+    const useSpy = vi.spyOn(client.interceptors.response, 'use')
+
+    attachLinkedPrimaryAccountResponseInterceptor(client, handler)
+
+    expect(useSpy).toHaveBeenCalled()
+    const onRejected = useSpy.mock.calls[0][1] as (err: unknown) => Promise<unknown>
+    const rejection = err409({})
+
+    await expect(onRejected(rejection)).rejects.toBe(rejection)
+
+    expect(handler).toHaveBeenCalledTimes(1)
+    expect(wasLinkedPrimaryAuthHandled(rejection)).toBe(true)
+  })
+
+  it('does not invoke handler when error is not linked-primary', async () => {
+    const handler = vi.fn()
+    const client = axios.create()
+    const useSpy = vi.spyOn(client.interceptors.response, 'use')
+
+    attachLinkedPrimaryAccountResponseInterceptor(client, handler)
+
+    const onRejected = useSpy.mock.calls[0][1] as (err: unknown) => Promise<unknown>
+    const rejection = err409({
+      url: '/remote.php/dav/files/foo',
+      data: { error: { code: 'linkedPrimaryAccount' } }
+    })
+
+    await expect(onRejected(rejection)).rejects.toBe(rejection)
+    expect(handler).not.toHaveBeenCalled()
+    expect(wasLinkedPrimaryAuthHandled(rejection)).toBe(false)
+  })
+})

--- a/packages/web-pkg/tests/unit/helpers/auth/linkedPrimaryAccountError.spec.ts
+++ b/packages/web-pkg/tests/unit/helpers/auth/linkedPrimaryAccountError.spec.ts
@@ -37,10 +37,10 @@ describe('isLinkedPrimaryAccountError', () => {
     expect(isLinkedPrimaryAccountError(new Error('oops'))).toBe(false)
   })
 
-  it('returns false for 409 on non-bootstrap URLs', () => {
+  it('returns false for 409 without linked-primary signal', () => {
     const error = err409({
       url: '/remote.php/dav/files/foo',
-      data: { error: { code: 'linkedPrimaryAccount' } }
+      data: { error: { code: 'resourceAlreadyExists' } }
     })
     expect(isLinkedPrimaryAccountError(error)).toBe(false)
   })
@@ -65,6 +65,23 @@ describe('isLinkedPrimaryAccountError', () => {
     const error = err409({
       data: {},
       headers: { 'x-oc-linked-primary-account': 'true' }
+    })
+    expect(isLinkedPrimaryAccountError(error)).toBe(true)
+  })
+
+  it('returns true for trusted linked-primary header on protected endpoint URLs', () => {
+    const error = err409({
+      url: '/api/v0/storage/spaces',
+      data: {},
+      headers: { 'x-oc-linked-primary-account': 'true' }
+    })
+    expect(isLinkedPrimaryAccountError(error)).toBe(true)
+  })
+
+  it('returns true for linked-primary code on protected endpoint URLs', () => {
+    const error = err409({
+      url: '/api/v0/storage/spaces',
+      data: { error: { code: 'linkedPrimaryAccount' } }
     })
     expect(isLinkedPrimaryAccountError(error)).toBe(true)
   })
@@ -112,6 +129,19 @@ describe('isLinkedPrimaryAccountError', () => {
     })
     expect(isLinkedPrimaryAccountError(error)).toBe(true)
   })
+
+  it('returns false when only error.message suggests linked primary on non-bootstrap URLs', () => {
+    const error = err409({
+      url: '/api/v0/files/some-operation',
+      data: {
+        error: {
+          code: 'unknown',
+          message: 'Your linked primary account cannot access this application'
+        }
+      }
+    })
+    expect(isLinkedPrimaryAccountError(error)).toBe(false)
+  })
 })
 
 describe('linkedPrimaryAuthHandled marker', () => {
@@ -151,7 +181,7 @@ describe('attachLinkedPrimaryAccountResponseInterceptor', () => {
     const onRejected = useSpy.mock.calls[0][1] as (err: unknown) => Promise<unknown>
     const rejection = err409({
       url: '/remote.php/dav/files/foo',
-      data: { error: { code: 'linkedPrimaryAccount' } }
+      data: { error: { code: 'resourceAlreadyExists' } }
     })
 
     await expect(onRejected(rejection)).rejects.toBe(rejection)

--- a/packages/web-runtime/src/container/bootstrap.ts
+++ b/packages/web-runtime/src/container/bootstrap.ts
@@ -567,7 +567,7 @@ export const announceAuthService = ({
     webWorkersStore
   )
   ;(clientService as ClientService).attachLinkedPrimaryAccountHandling((err) =>
-    authService.handleAuthError(unref(router.currentRoute), { cause: err })
+    authService.handleAuthError(unref(router.currentRoute), { cause: err }).then(() => undefined)
   )
 
   app.config.globalProperties.$authService = authService

--- a/packages/web-runtime/src/container/bootstrap.ts
+++ b/packages/web-runtime/src/container/bootstrap.ts
@@ -1,7 +1,7 @@
 import { registerClient } from '../services/clientRegistration'
 import { buildApplication, NextApplication } from './application'
 import { RouteLocationRaw, Router, RouteRecordNormalized } from 'vue-router'
-import { App, computed, watch } from 'vue'
+import { App, computed, watch, unref } from 'vue'
 import { loadTheme } from '../helpers/theme'
 import { createGettext, GetTextOptions, Language, Translations } from 'vue3-gettext'
 import { getBackendVersion, getWebVersion } from './versions'
@@ -566,6 +566,10 @@ export const announceAuthService = ({
     capabilityStore,
     webWorkersStore
   )
+  ;(clientService as ClientService).attachLinkedPrimaryAccountHandling((err) =>
+    authService.handleAuthError(unref(router.currentRoute), { cause: err })
+  )
+
   app.config.globalProperties.$authService = authService
   app.provide('$authService', authService)
 }

--- a/packages/web-runtime/src/pages/linkedAccountBlocked.vue
+++ b/packages/web-runtime/src/pages/linkedAccountBlocked.vue
@@ -1,0 +1,130 @@
+<template>
+  <div class="oc-height-viewport oc-flex oc-flex-column oc-flex-center oc-flex-middle">
+    <div class="oc-login-card">
+      <img class="oc-login-logo" :src="logoImg" alt="" :aria-hidden="true" />
+      <div class="oc-login-card-body oc-width-medium">
+        <h2 class="oc-login-card-title" v-text="cardTitle" />
+        <p v-text="cardHint" />
+        <div v-if="linkedAccountDocUrl || linkedAccountPortalUrl" class="oc-mt-m">
+          <oc-button
+            v-if="linkedAccountDocUrl"
+            type="a"
+            appearance="raw"
+            :href="linkedAccountDocUrl"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <span v-text="$gettext('Read documentation')" />
+          </oc-button>
+          <oc-button
+            v-if="linkedAccountPortalUrl"
+            type="a"
+            appearance="raw"
+            class="oc-mt-s"
+            :href="linkedAccountPortalUrl"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <span v-text="$gettext('Open user portal to unlink')" />
+          </oc-button>
+        </div>
+      </div>
+      <div class="oc-login-card-footer oc-pt-rm">
+        <p>
+          {{ footerSlogan }}
+        </p>
+      </div>
+    </div>
+    <oc-button
+      id="exitAnchor"
+      class="oc-mt-m oc-width-medium"
+      size="large"
+      appearance="filled"
+      variation="primary"
+      v-bind="logoutButtonsAttrs"
+    >
+      {{ navigateToLoginText }}
+    </oc-button>
+  </div>
+</template>
+
+<script lang="ts">
+import { computed, defineComponent, unref } from 'vue'
+import { useGettext } from 'vue3-gettext'
+import { storeToRefs } from 'pinia'
+import {
+  queryItemAsString,
+  useConfigStore,
+  useRouteQuery,
+  useThemeStore
+} from '@ownclouders/web-pkg'
+
+export default defineComponent({
+  name: 'LinkedAccountBlockedPage',
+  setup() {
+    const themeStore = useThemeStore()
+    const { currentTheme } = storeToRefs(themeStore)
+    const configStore = useConfigStore()
+    const redirectUrlQuery = useRouteQuery('redirectUrl')
+
+    const { $gettext } = useGettext()
+
+    const footerSlogan = computed(() => currentTheme.value.common.slogan)
+    const logoImg = computed(() => currentTheme.value.logo.login)
+
+    const linkedAccountDocUrl = computed(() => configStore.options.linkedAccount?.docUrl || '')
+    const linkedAccountPortalUrl = computed(() => {
+      const explicit = configStore.options.linkedAccount?.userPortalUrl
+      if (explicit) {
+        return explicit
+      }
+      return configStore.options.accountEditLink?.href || ''
+    })
+
+    const cardTitle = computed(() => {
+      return $gettext('Sign-in blocked')
+    })
+    const cardHint = computed(() => {
+      return $gettext(
+        'You signed in with an identity that is linked as a primary account elsewhere. This application cannot be used with that account until it is unlinked.'
+      )
+    })
+    const navigateToLoginText = computed(() => {
+      return $gettext('Log in again')
+    })
+    const logoutButtonsAttrs = computed(() => {
+      const redirectUrl = queryItemAsString(unref(redirectUrlQuery))
+      if (configStore.options.loginUrl) {
+        const configLoginURL = new URL(encodeURI(configStore.options.loginUrl))
+        if (redirectUrl) {
+          configLoginURL.searchParams.append('redirectUrl', redirectUrl)
+        }
+        return {
+          type: 'a',
+          href: configLoginURL.toString()
+        }
+      }
+      return {
+        type: 'router-link',
+        to: {
+          name: 'login',
+          query: {
+            ...(redirectUrl && { redirectUrl })
+          }
+        }
+      }
+    })
+
+    return {
+      logoImg,
+      cardTitle,
+      cardHint,
+      footerSlogan,
+      navigateToLoginText,
+      linkedAccountDocUrl,
+      linkedAccountPortalUrl,
+      logoutButtonsAttrs
+    }
+  }
+})
+</script>

--- a/packages/web-runtime/src/pages/linkedAccountBlocked.vue
+++ b/packages/web-runtime/src/pages/linkedAccountBlocked.vue
@@ -43,23 +43,19 @@
       size="large"
       appearance="filled"
       variation="primary"
-      v-bind="logoutButtonsAttrs"
+      @click="logout"
     >
-      {{ navigateToLoginText }}
+      {{ logoutButtonText }}
     </oc-button>
   </div>
 </template>
 
 <script lang="ts">
-import { computed, defineComponent, unref } from 'vue'
+import { computed, defineComponent } from 'vue'
 import { useGettext } from 'vue3-gettext'
 import { storeToRefs } from 'pinia'
-import {
-  queryItemAsString,
-  useConfigStore,
-  useRouteQuery,
-  useThemeStore
-} from '@ownclouders/web-pkg'
+import { useConfigStore, useThemeStore } from '@ownclouders/web-pkg'
+import { authService } from '../services/auth'
 
 const DEFAULT_LINKED_ACCOUNT_DOC_URL =
   'https://auth.docs.cern.ch/user-documentation/verified-guest/'
@@ -71,7 +67,6 @@ export default defineComponent({
     const themeStore = useThemeStore()
     const { currentTheme } = storeToRefs(themeStore)
     const configStore = useConfigStore()
-    const redirectUrlQuery = useRouteQuery('redirectUrl')
 
     const { $gettext } = useGettext()
 
@@ -97,41 +92,23 @@ export default defineComponent({
         'You signed in with an identity that is linked as a primary account elsewhere. This application cannot be used with that account until it is unlinked.'
       )
     })
-    const navigateToLoginText = computed(() => {
-      return $gettext('Log in again')
+    const logoutButtonText = computed(() => {
+      return $gettext('Log out')
     })
-    const logoutButtonsAttrs = computed(() => {
-      const redirectUrl = queryItemAsString(unref(redirectUrlQuery))
-      if (configStore.options.loginUrl) {
-        const configLoginURL = new URL(encodeURI(configStore.options.loginUrl))
-        if (redirectUrl) {
-          configLoginURL.searchParams.append('redirectUrl', redirectUrl)
-        }
-        return {
-          type: 'a',
-          href: configLoginURL.toString()
-        }
-      }
-      return {
-        type: 'router-link',
-        to: {
-          name: 'login',
-          query: {
-            ...(redirectUrl && { redirectUrl })
-          }
-        }
-      }
-    })
+
+    const logout = () => {
+      return authService.logoutUser()
+    }
 
     return {
       logoImg,
       cardTitle,
       cardHint,
       footerSlogan,
-      navigateToLoginText,
+      logoutButtonText,
       linkedAccountDocUrl,
       linkedAccountPortalUrl,
-      logoutButtonsAttrs
+      logout
     }
   }
 })

--- a/packages/web-runtime/src/pages/linkedAccountBlocked.vue
+++ b/packages/web-runtime/src/pages/linkedAccountBlocked.vue
@@ -8,6 +8,7 @@
         <div v-if="linkedAccountDocUrl || linkedAccountPortalUrl" class="oc-mt-m">
           <oc-button
             v-if="linkedAccountDocUrl"
+            data-testid="linked-account-doc-link"
             type="a"
             appearance="raw"
             :href="linkedAccountDocUrl"
@@ -18,6 +19,7 @@
           </oc-button>
           <oc-button
             v-if="linkedAccountPortalUrl"
+            data-testid="linked-account-portal-link"
             type="a"
             appearance="raw"
             class="oc-mt-s"
@@ -59,6 +61,10 @@ import {
   useThemeStore
 } from '@ownclouders/web-pkg'
 
+const DEFAULT_LINKED_ACCOUNT_DOC_URL =
+  'https://auth.docs.cern.ch/user-documentation/verified-guest/'
+const DEFAULT_LINKED_ACCOUNT_PORTAL_URL = 'https://account.cern.ch/account/'
+
 export default defineComponent({
   name: 'LinkedAccountBlockedPage',
   setup() {
@@ -72,13 +78,15 @@ export default defineComponent({
     const footerSlogan = computed(() => currentTheme.value.common.slogan)
     const logoImg = computed(() => currentTheme.value.logo.login)
 
-    const linkedAccountDocUrl = computed(() => configStore.options.linkedAccount?.docUrl || '')
+    const linkedAccountDocUrl = computed(
+      () => configStore.options.linkedAccount?.docUrl || DEFAULT_LINKED_ACCOUNT_DOC_URL
+    )
     const linkedAccountPortalUrl = computed(() => {
       const explicit = configStore.options.linkedAccount?.userPortalUrl
       if (explicit) {
         return explicit
       }
-      return configStore.options.accountEditLink?.href || ''
+      return configStore.options.accountEditLink?.href || DEFAULT_LINKED_ACCOUNT_PORTAL_URL
     })
 
     const cardTitle = computed(() => {

--- a/packages/web-runtime/src/router/index.ts
+++ b/packages/web-runtime/src/router/index.ts
@@ -1,4 +1,5 @@
 import AccessDeniedPage from '../pages/accessDenied.vue'
+import LinkedAccountBlockedPage from '../pages/linkedAccountBlocked.vue'
 import Account from '../pages/account.vue'
 import LoginPage from '../pages/login.vue'
 import LogoutPage from '../pages/logout.vue'
@@ -81,6 +82,12 @@ const routes = [
     name: 'accessDenied',
     component: AccessDeniedPage,
     meta: { title: $gettext('Access denied'), authContext: 'anonymous' }
+  },
+  {
+    path: '/linked-account-blocked',
+    name: 'linkedAccountBlocked',
+    component: LinkedAccountBlockedPage,
+    meta: { title: $gettext('Account linking'), authContext: 'anonymous' }
   },
   {
     path: '/account',

--- a/packages/web-runtime/src/router/setupAuthGuard.ts
+++ b/packages/web-runtime/src/router/setupAuthGuard.ts
@@ -27,10 +27,11 @@ export const setupAuthGuard = (router: Router) => {
     await authService.initializeContext(to)
 
     // vue-router currently (4.1.6) does not cancel navigations when a new one is triggered
-    // we need to guard this case to be able to show the access denied page
+    // we need to guard this case to be able to show access denied or linked-account blocked
     // and not be redirected to the login page
     if (authService.hasAuthErrorOccurred) {
-      return to.name === 'accessDenied' || { name: 'accessDenied' }
+      const blockRoute = authService.authBlockRouteName
+      return to.name === blockRoute || { name: blockRoute }
     }
 
     if (isPublicLinkContextRequired(router, to)) {
@@ -70,10 +71,11 @@ export const setupAuthGuard = (router: Router) => {
     return true
   })
   router.afterEach((to) => {
-    if (to.name !== 'accessDenied') {
+    if (to.name !== 'accessDenied' && to.name !== 'linkedAccountBlocked') {
       return
     }
     authService.hasAuthErrorOccurred = false
+    authService.authBlockRouteName = 'accessDenied'
   })
 }
 

--- a/packages/web-runtime/src/services/auth/authService.ts
+++ b/packages/web-runtime/src/services/auth/authService.ts
@@ -1,13 +1,17 @@
 import { UserManager } from './userManager'
 import { PublicLinkManager } from './publicLinkManager'
+import { Ability, PublicLinkType } from '@ownclouders/web-client'
 import {
   AuthStore,
   ClientService,
-  UserStore,
+  AuthServiceInterface,
   CapabilityStore,
   ConfigStore,
+  isLinkedPrimaryAccountError,
   useTokenTimerWorker,
-  AuthServiceInterface
+  UserStore,
+  wasLinkedPrimaryAuthHandled,
+  WebWorkersStore
 } from '@ownclouders/web-pkg'
 import { RouteLocation, Router } from 'vue-router'
 import {
@@ -18,11 +22,10 @@ import {
   isUserContextRequired
 } from '../../router'
 import { unref } from 'vue'
-import { Ability } from '@ownclouders/web-client'
 import { Language } from 'vue3-gettext'
-import { PublicLinkType } from '@ownclouders/web-client'
-import { WebWorkersStore } from '@ownclouders/web-pkg'
 import { isSilentRedirectRoute } from '../../helpers/silentRedirect'
+
+export type AuthBlockRouteName = 'accessDenied' | 'linkedAccountBlocked'
 
 export class AuthService implements AuthServiceInterface {
   private clientService: ClientService
@@ -44,6 +47,7 @@ export class AuthService implements AuthServiceInterface {
   private accessTokenExpiryThreshold = 10
 
   public hasAuthErrorOccurred: boolean
+  public authBlockRouteName: AuthBlockRouteName = 'accessDenied'
 
   public initialize(
     configStore: ConfigStore,
@@ -60,6 +64,7 @@ export class AuthService implements AuthServiceInterface {
     this.clientService = clientService
     this.router = router
     this.hasAuthErrorOccurred = false
+    this.authBlockRouteName = 'accessDenied'
     this.ability = ability
     this.language = language
     this.userStore = userStore
@@ -166,7 +171,7 @@ export class AuthService implements AuthServiceInterface {
             await this.userManager.updateContext(user.access_token, fetchUserData)
           } catch (e) {
             console.error(e)
-            await this.handleAuthError(unref(this.router.currentRoute))
+            await this.handleAuthError(unref(this.router.currentRoute), { cause: e })
           }
         })
 
@@ -178,7 +183,7 @@ export class AuthService implements AuthServiceInterface {
           if (this.userManager.unloadReason === 'authError') {
             this.hasAuthErrorOccurred = true
             return this.router.push({
-              name: 'accessDenied',
+              name: this.authBlockRouteName,
               query: { redirectUrl: unref(this.router.currentRoute)?.fullPath }
             })
           }
@@ -193,14 +198,14 @@ export class AuthService implements AuthServiceInterface {
         })
         this.userManager.events.addSilentRenewError(async (error) => {
           console.error('Silent Renew Error：', error)
-          await this.handleAuthError(unref(this.router.currentRoute))
+          await this.handleAuthError(unref(this.router.currentRoute), { cause: error })
         })
 
         this.userManager.areEventHandlersRegistered = true
       }
 
       // This is to prevent issues in embed mode when the expired token is still saved but already expired
-      // If the following code gets executed, it would toggle errorOccurred var which would then lead to redirect to the access denied screen
+      // If the following code runs it toggles errorOccurred and leads to accessDenied / linkedAccountBlocked
       if (
         this.configStore.options.embed?.enabled &&
         this.configStore.options.embed.delegateAuthentication
@@ -228,7 +233,7 @@ export class AuthService implements AuthServiceInterface {
           }
         } catch (e) {
           console.error(e)
-          await this.handleAuthError(unref(this.router.currentRoute))
+          await this.handleAuthError(unref(this.router.currentRoute), { cause: e })
         }
       }
     }
@@ -270,7 +275,7 @@ export class AuthService implements AuthServiceInterface {
       })
     } catch (e) {
       console.warn('error during authentication:', e)
-      return this.handleAuthError(unref(this.router.currentRoute))
+      return this.handleAuthError(unref(this.router.currentRoute), { cause: e })
     }
   }
 
@@ -295,8 +300,11 @@ export class AuthService implements AuthServiceInterface {
 
   public async handleAuthError(
     route: RouteLocation,
-    { forceLogout = false }: { forceLogout?: boolean } = {}
+    { forceLogout = false, cause }: { forceLogout?: boolean; cause?: unknown } = {}
   ) {
+    if (cause !== undefined && wasLinkedPrimaryAuthHandled(cause)) {
+      return
+    }
     if (isPublicLinkContextRequired(this.router, route)) {
       const token = extractPublicLinkToken(route)
       this.publicLinkManager.clear(token)
@@ -319,14 +327,22 @@ export class AuthService implements AuthServiceInterface {
         return
       }
 
+      this.setAuthBlockRouteFromCause(cause)
       await this.userManager.removeUser('authError')
       this.tokenTimerWorker?.resetTokenTimer()
       return
     }
-    // authGuard is taking care of redirecting the user to the
-    // accessDenied page if hasAuthErrorOccurred is set to true
-    // we can't push the route ourselves, see authGuard for details.
+    // authGuard redirects via `hasAuthErrorOccurred` to `accessDenied` or `linkedAccountBlocked`
+    // when neither user nor IdP context can proceed; see setupAuthGuard.
+    this.setAuthBlockRouteFromCause(cause)
     this.hasAuthErrorOccurred = true
+  }
+
+  private setAuthBlockRouteFromCause(cause: unknown) {
+    this.authBlockRouteName =
+      cause !== undefined && isLinkedPrimaryAccountError(cause)
+        ? 'linkedAccountBlocked'
+        : 'accessDenied'
   }
 
   public async resolvePublicLink(

--- a/packages/web-runtime/tests/unit/pages/__snapshots__/linkedAccountBlocked.spec.ts.snap
+++ b/packages/web-runtime/tests/unit/pages/__snapshots__/linkedAccountBlocked.spec.ts.snap
@@ -6,7 +6,13 @@ exports[`linked account blocked page > renders component 1`] = `
     <div class="oc-login-card-body oc-width-medium">
       <h2 class="oc-login-card-title">Sign-in blocked</h2>
       <p>You signed in with an identity that is linked as a primary account elsewhere. This application cannot be used with that account until it is unlinked.</p>
-      <!--v-if-->
+      <div class="oc-mt-m"><a href="https://auth.docs.cern.ch/user-documentation/verified-guest/" target="_blank" class="oc-button oc-rounded oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-passive oc-button-passive-raw" data-testid="linked-account-doc-link" rel="noopener noreferrer">
+          <!--v-if-->
+          <!-- @slot Content of the button --> <span>Read documentation</span>
+        </a> <a href="https://account.cern.ch/account/" target="_blank" class="oc-button oc-rounded oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-passive oc-button-passive-raw oc-mt-s" data-testid="linked-account-portal-link" rel="noopener noreferrer">
+          <!--v-if-->
+          <!-- @slot Content of the button --> <span>Open user portal to unlink</span>
+        </a></div>
     </div>
     <div class="oc-login-card-footer oc-pt-rm">
       <p>ownCloud – A safe home for all your data</p>

--- a/packages/web-runtime/tests/unit/pages/__snapshots__/linkedAccountBlocked.spec.ts.snap
+++ b/packages/web-runtime/tests/unit/pages/__snapshots__/linkedAccountBlocked.spec.ts.snap
@@ -17,6 +17,9 @@ exports[`linked account blocked page > renders component 1`] = `
     <div class="oc-login-card-footer oc-pt-rm">
       <p>ownCloud – A safe home for all your data</p>
     </div>
-  </div> <a attrs="[object Object]" class="oc-button oc-rounded oc-button-l oc-button-justify-content-center oc-button-gap-m oc-button-primary oc-button-primary-filled oc-mt-m oc-width-medium" id="exitAnchor"></a>
+  </div> <button type="button" class="oc-button oc-rounded oc-button-l oc-button-justify-content-center oc-button-gap-m oc-button-primary oc-button-primary-filled oc-mt-m oc-width-medium" id="exitAnchor">
+    <!--v-if-->
+    <!-- @slot Content of the button --> Log out
+  </button>
 </div>"
 `;

--- a/packages/web-runtime/tests/unit/pages/__snapshots__/linkedAccountBlocked.spec.ts.snap
+++ b/packages/web-runtime/tests/unit/pages/__snapshots__/linkedAccountBlocked.spec.ts.snap
@@ -1,0 +1,16 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`linked account blocked page > renders component 1`] = `
+"<div class="oc-height-viewport oc-flex oc-flex-column oc-flex-center oc-flex-middle">
+  <div class="oc-login-card"><img class="oc-login-logo" src="themes/owncloud/assets/logo.svg" alt="" aria-hidden="true">
+    <div class="oc-login-card-body oc-width-medium">
+      <h2 class="oc-login-card-title">Sign-in blocked</h2>
+      <p>You signed in with an identity that is linked as a primary account elsewhere. This application cannot be used with that account until it is unlinked.</p>
+      <!--v-if-->
+    </div>
+    <div class="oc-login-card-footer oc-pt-rm">
+      <p>ownCloud – A safe home for all your data</p>
+    </div>
+  </div> <a attrs="[object Object]" class="oc-button oc-rounded oc-button-l oc-button-justify-content-center oc-button-gap-m oc-button-primary oc-button-primary-filled oc-mt-m oc-width-medium" id="exitAnchor"></a>
+</div>"
+`;

--- a/packages/web-runtime/tests/unit/pages/linkedAccountBlocked.spec.ts
+++ b/packages/web-runtime/tests/unit/pages/linkedAccountBlocked.spec.ts
@@ -7,6 +7,49 @@ describe('linked account blocked page', () => {
     expect(wrapper.html()).toMatchSnapshot()
   })
 
+  it('renders default documentation and unlink portal links', () => {
+    const { wrapper } = getWrapper()
+
+    expect(wrapper.find('[data-testid="linked-account-doc-link"]').attributes('href')).toBe(
+      'https://auth.docs.cern.ch/user-documentation/verified-guest/'
+    )
+    expect(wrapper.find('[data-testid="linked-account-portal-link"]').attributes('href')).toBe(
+      'https://account.cern.ch/account/'
+    )
+  })
+
+  it('renders configured documentation and unlink portal links', () => {
+    const { wrapper } = getWrapper({
+      linkedAccount: {
+        docUrl: 'https://docs.example.test/linked-account',
+        userPortalUrl: 'https://portal.example.test/linked-accounts'
+      }
+    })
+
+    const docLink = wrapper.find('[data-testid="linked-account-doc-link"]')
+    const portalLink = wrapper.find('[data-testid="linked-account-portal-link"]')
+
+    expect(docLink.attributes('href')).toBe('https://docs.example.test/linked-account')
+    expect(docLink.attributes('target')).toBe('_blank')
+    expect(docLink.attributes('rel')).toBe('noopener noreferrer')
+    expect(portalLink.attributes('href')).toBe('https://portal.example.test/linked-accounts')
+    expect(portalLink.attributes('target')).toBe('_blank')
+    expect(portalLink.attributes('rel')).toBe('noopener noreferrer')
+  })
+
+  it('uses accountEditLink as unlink portal fallback', () => {
+    const { wrapper } = getWrapper({
+      accountEditLink: { href: 'https://account.example.test/edit' },
+      linkedAccount: {
+        docUrl: 'https://docs.example.test/linked-account'
+      }
+    })
+
+    expect(wrapper.find('[data-testid="linked-account-portal-link"]').attributes('href')).toBe(
+      'https://account.example.test/edit'
+    )
+  })
+
   describe('"Log in again" button', () => {
     it('navigates to "loginUrl" if set in config', () => {
       const loginUrl = 'https://myidp.int/login'
@@ -24,6 +67,7 @@ describe('linked account blocked page', () => {
 
 function getWrapper({
   loginUrl = '',
+  accountEditLink = undefined as { href?: string } | undefined,
   linkedAccount = undefined as { docUrl?: string; userPortalUrl?: string } | undefined
 } = {}) {
   const mocks = {
@@ -40,6 +84,7 @@ function getWrapper({
               configState: {
                 options: {
                   loginUrl,
+                  ...(accountEditLink !== undefined && { accountEditLink }),
                   ...(linkedAccount !== undefined && { linkedAccount })
                 }
               }

--- a/packages/web-runtime/tests/unit/pages/linkedAccountBlocked.spec.ts
+++ b/packages/web-runtime/tests/unit/pages/linkedAccountBlocked.spec.ts
@@ -1,0 +1,54 @@
+import linkedAccountBlocked from '../../../src/pages/linkedAccountBlocked.vue'
+import { defaultComponentMocks, defaultPlugins, mount } from '@ownclouders/web-test-helpers'
+
+describe('linked account blocked page', () => {
+  it('renders component', () => {
+    const { wrapper } = getWrapper()
+    expect(wrapper.html()).toMatchSnapshot()
+  })
+
+  describe('"Log in again" button', () => {
+    it('navigates to "loginUrl" if set in config', () => {
+      const loginUrl = 'https://myidp.int/login'
+      const { wrapper } = getWrapper({ loginUrl })
+
+      const logInAgainButton = wrapper.find('#exitAnchor')
+      const loginAgainUrl = new URL(logInAgainButton.attributes().href)
+      loginAgainUrl.search = ''
+
+      expect(logInAgainButton.exists()).toBeTruthy()
+      expect(loginAgainUrl.toString()).toEqual(loginUrl)
+    })
+  })
+})
+
+function getWrapper({
+  loginUrl = '',
+  linkedAccount = undefined as { docUrl?: string; userPortalUrl?: string } | undefined
+} = {}) {
+  const mocks = {
+    ...defaultComponentMocks()
+  }
+
+  return {
+    mocks,
+    wrapper: mount(linkedAccountBlocked, {
+      global: {
+        plugins: [
+          ...defaultPlugins({
+            piniaOptions: {
+              configState: {
+                options: {
+                  loginUrl,
+                  ...(linkedAccount !== undefined && { linkedAccount })
+                }
+              }
+            }
+          })
+        ],
+        mocks,
+        provide: mocks
+      }
+    })
+  }
+}

--- a/packages/web-runtime/tests/unit/pages/linkedAccountBlocked.spec.ts
+++ b/packages/web-runtime/tests/unit/pages/linkedAccountBlocked.spec.ts
@@ -1,5 +1,7 @@
 import linkedAccountBlocked from '../../../src/pages/linkedAccountBlocked.vue'
+import { authService } from '../../../src/services/auth'
 import { defaultComponentMocks, defaultPlugins, mount } from '@ownclouders/web-test-helpers'
+import { vi } from 'vitest'
 
 describe('linked account blocked page', () => {
   it('renders component', () => {
@@ -50,17 +52,14 @@ describe('linked account blocked page', () => {
     )
   })
 
-  describe('"Log in again" button', () => {
-    it('navigates to "loginUrl" if set in config', () => {
-      const loginUrl = 'https://myidp.int/login'
-      const { wrapper } = getWrapper({ loginUrl })
+  describe('"Log out" button', () => {
+    it('calls authService.logoutUser when clicked', async () => {
+      const logoutUserSpy = vi.spyOn(authService, 'logoutUser').mockResolvedValue(undefined)
+      const { wrapper } = getWrapper()
 
-      const logInAgainButton = wrapper.find('#exitAnchor')
-      const loginAgainUrl = new URL(logInAgainButton.attributes().href)
-      loginAgainUrl.search = ''
+      await wrapper.find('#exitAnchor').trigger('click')
 
-      expect(logInAgainButton.exists()).toBeTruthy()
-      expect(loginAgainUrl.toString()).toEqual(loginUrl)
+      expect(logoutUserSpy).toHaveBeenCalledTimes(1)
     })
   })
 })

--- a/packages/web-runtime/tests/unit/services/auth/authService.spec.ts
+++ b/packages/web-runtime/tests/unit/services/auth/authService.spec.ts
@@ -1,14 +1,41 @@
-import { ConfigStore, useAuthStore, useConfigStore } from '@ownclouders/web-pkg'
+import {
+  ConfigStore,
+  markLinkedPrimaryAuthHandled,
+  useAuthStore,
+  useConfigStore
+} from '@ownclouders/web-pkg'
+import { AxiosError, InternalAxiosRequestConfig } from 'axios'
 import { mock } from 'vitest-mock-extended'
 import { Router } from 'vue-router'
 import { AuthService } from '../../../../src/services/auth/authService'
 import { UserManager } from '../../../../src/services/auth/userManager'
+import * as routerHelpers from '../../../../src/router'
 import { RouteLocation, createRouter, createTestingPinia } from '@ownclouders/web-test-helpers'
 
 const mockUpdateContext = vi.fn()
 console.debug = vi.fn()
 
 vi.mock('../../../../src/services/auth/userManager')
+
+function linkedPrimaryCause(): AxiosError {
+  return new AxiosError(
+    'conflict',
+    'ERR_BAD_REQUEST',
+    {
+      url: '/graph/v1.0/me',
+      baseURL: 'https://example.com/',
+      headers: {}
+    } as InternalAxiosRequestConfig,
+    {},
+    {
+      status: 409,
+      statusText: 'Conflict',
+      data: { error: { code: 'linkedPrimaryAccount', message: 'x' } },
+      headers: {},
+      config: {} as AxiosError['config']
+    }
+  )
+}
 
 const initAuthService = ({
   authService,
@@ -151,6 +178,83 @@ describe('AuthService', () => {
       await authService.initializeContext(mock<RouteLocation>({}))
 
       expect(mockUpdateContext).toHaveBeenCalledWith('access-token', true)
+    })
+  })
+
+  describe('handleAuthError', () => {
+    describe('linked-primary cause routing', () => {
+      beforeEach(() => {
+        vi.spyOn(routerHelpers, 'isPublicLinkContextRequired').mockReturnValue(false)
+        vi.spyOn(routerHelpers, 'isUserContextRequired').mockReturnValue(true)
+        vi.spyOn(routerHelpers, 'isIdpContextRequired').mockReturnValue(false)
+      })
+
+      afterEach(() => {
+        vi.restoreAllMocks()
+      })
+
+      it('sets authBlockRouteName to linkedAccountBlocked when cause matches linked primary', async () => {
+        const authService = new AuthService()
+        const removeUser = vi.fn().mockResolvedValue(undefined)
+        Object.defineProperty(authService, 'userManager', {
+          value: mock<UserManager>({
+            getUser: vi.fn().mockResolvedValue({ expires_in: 3600 }),
+            removeUser
+          })
+        })
+
+        const router = createRouter()
+        initAuthService({ authService, router })
+
+        await authService.handleAuthError(mock<RouteLocation>({}), {
+          cause: linkedPrimaryCause()
+        })
+
+        expect(authService.authBlockRouteName).toBe('linkedAccountBlocked')
+        expect(removeUser).toHaveBeenCalledWith('authError')
+      })
+
+      it('sets authBlockRouteName to accessDenied for generic errors', async () => {
+        const authService = new AuthService()
+        const removeUser = vi.fn().mockResolvedValue(undefined)
+        Object.defineProperty(authService, 'userManager', {
+          value: mock<UserManager>({
+            getUser: vi.fn().mockResolvedValue({ expires_in: 3600 }),
+            removeUser
+          })
+        })
+
+        const router = createRouter()
+        initAuthService({ authService, router })
+
+        await authService.handleAuthError(mock<RouteLocation>({}), {
+          cause: new Error('generic')
+        })
+
+        expect(authService.authBlockRouteName).toBe('accessDenied')
+        expect(removeUser).toHaveBeenCalledWith('authError')
+      })
+
+      it('does not call removeUser twice when cause already marked handled by interceptor', async () => {
+        const authService = new AuthService()
+        const removeUser = vi.fn().mockResolvedValue(undefined)
+        Object.defineProperty(authService, 'userManager', {
+          value: mock<UserManager>({
+            getUser: vi.fn().mockResolvedValue({ expires_in: 3600 }),
+            removeUser
+          })
+        })
+
+        const router = createRouter()
+        initAuthService({ authService, router })
+
+        const cause = linkedPrimaryCause()
+        await authService.handleAuthError(mock<RouteLocation>({}), { cause })
+        markLinkedPrimaryAuthHandled(cause)
+        await authService.handleAuthError(mock<RouteLocation>({}), { cause })
+
+        expect(removeUser).toHaveBeenCalledTimes(1)
+      })
     })
   })
 })


### PR DESCRIPTION
## Summary

When a user signs in with an identity that CERNBox blocks as a linked primary account, the backend returns **HTTP 409** with a machine-readable linked-primary contract (Reva `http.interceptors.auth`, documented as `identity-auth-http-errors`). Previously, Web treated that like a generic auth failure and sent users to **Access denied**.

This PR detects that contract on Graph, OCS, and authenticated HTTP responses, routes auth errors to a new **`linkedAccountBlocked`** page, and surfaces configurable links to documentation and the user portal where the account can be unlinked.

**Companion change (separate repo):** [cs3org/reva](https://github.com/cs3org/reva) branch `feat/4348-linked-primary-http-contract` adds the HTTP response shape (`409`, `X-Oc-Linked-Primary-Account: true`, JSON `error.code: linkedPrimaryAccount`). **Detection in production also depends on** [cernbox/reva-plugins](https://github.com/cernbox/reva-plugins) (v0.0.37+, “block linked accounts”) via the REST user provider.

---

## Problem

- Users signing in with a blocked linked-primary identity saw a generic **Access denied** screen with no guidance.
- **409 Conflict** is used elsewhere in Web (for example WebDAV autosave), so detection must not rely on status code alone.
- CERNBox uses `useRevaToken` and multiple HTTP stacks (Graph, OCS, authenticated HTTP); handling must be centralized.

---

## Solution

### Backend contract (consumer)

Web treats a response as linked-primary when:

| Signal | Value |
|--------|--------|
| Status | `409 Conflict` |
| Header | `X-Oc-Linked-Primary-Account: true` |
| Body | `error.code` in `linkedPrimaryAccount` (and documented aliases) |
| Fallback | On identity bootstrap URLs only: `error.message` contains “linked primary account” |

Bootstrap paths include Graph `/me`, OCS user/capabilities, and settings URLs (see `isIdentityBootstrapRequestUrl`).

### Web changes

1. **`linkedPrimaryAccountError.ts`** — Shared detection, `createLinkedPrimaryRejectionHandler`, Axios interceptor helper, and a marker to avoid duplicate `handleAuthError` / `removeUser` calls.
2. **`ClientService.attachLinkedPrimaryAccountHandling`** — Registers handlers on Graph, OCS, and authenticated HTTP clients at bootstrap.
3. **`AuthService`** — Sets `authBlockRouteName` to `linkedAccountBlocked` when the error cause matches; auth guard keeps users on that route instead of login.
4. **`linkedAccountBlocked.vue`** — Dedicated page (same layout pattern as access denied) with:
   - Clear explanation copy
   - **Read documentation** (default: `https://auth.docs.cern.ch/user-documentation/verified-guest/`)
   - **Open user portal to unlink** (default: `https://account.cern.ch/account/`, or `options.accountEditLink.href`)
   - **Log in again** CTA
5. **Config** — Optional `options.linkedAccount.docUrl` and `options.linkedAccount.userPortalUrl` in `OptionsConfigSchema`.

### What we intentionally do not match

- Bare **409** without header/code/message contract (for example WebDAV file conflicts).
- Message-only matching on non-bootstrap URLs (avoids false positives on arbitrary APIs).

---

## Files changed

| Area | Files |
|------|--------|
| Detection / interceptors | `packages/web-pkg/src/helpers/auth/linkedPrimaryAccountError.ts`, `client.ts`, `http/client.ts` |
| Runtime / auth | `authService.ts`, `bootstrap.ts`, `setupAuthGuard.ts`, `useAuthService.ts` |
| UI | `linkedAccountBlocked.vue`, `router/index.ts` |
| Config | `config/types.ts` |
| Tests | `linkedPrimaryAccountError.spec.ts`, `linkedAccountBlocked.spec.ts`, `authService.spec.ts`, snapshot |

---

## Test plan

### Automated

- [x] `npx vitest run linkedPrimaryAccountError linkedAccountBlocked authService.spec` (33 tests)

### Manual (requires backend with full stack)

Deploy or point Web at a backend with:

- Reva HTTP contract branch (or equivalent 409 + header + JSON)
- `reva-plugins` ≥ v0.0.37 (linked-account block on `@cern.ch` username lookup)
- CERN-style OIDC (`useRevaToken` if applicable)

| Step | Action | Expected |
|------|--------|----------|
| 1 | Sign in as a **linked-primary / blocked** test user | — |
| 2 | Open Network tab; inspect bootstrap call (e.g. `GET .../graph/v1.0/me` or OCS user) | **409**, header `X-Oc-Linked-Primary-Account: true`, body `error.code: linkedPrimaryAccount` |
| 3 | Observe UI | **`/linked-account-blocked`** (not access denied): title “Sign-in blocked”, doc + portal links, “Log in again” |
| 4 | Sign in as a **normal** user | **200** on bootstrap; normal app load |
| 5 | Optional: set `options.linkedAccount` in `config.json` | Custom doc and portal URLs on blocked page |

### Regression

- [ ] File edit / autosave **409** still shows “file changed elsewhere”, not linked-account page.
- [ ] Generic auth failure still routes to **access denied**.

---

## Deployment notes

1. **Merge and ship Reva HTTP contract** (`feat/4348-linked-primary-http-contract`) in `revad` before or with this Web change; otherwise Web cannot detect the contract reliably.
2. **`reva-plugins`** is already required in CERN `revad` builds; no Web change needed there.
3. Optional puppet/config: add `options.linkedAccount` to `web.json` if defaults should differ per environment (defaults are CERN URLs in the Vue component).

---

## Related

- Ticket: **4348** — Show messages in web when getting 409 on user call (linked primary account)
- Reva: `feat/4348-linked-primary-http-contract`
- reva-plugins: PR #67 — block linked accounts (v0.0.37+)