### PR TITLE
feat(4336): sharing hierarchy conflict UX  (ADR-0005)

### DIFF
--- a/packages/web-app-files/src/components/SideBar/Shares/Collaborators/InviteCollaborator/InviteCollaboratorForm.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/Collaborators/InviteCollaborator/InviteCollaboratorForm.vue
@@ -151,7 +151,11 @@ import {
   CollaboratorShare,
   ShareRole,
   ShareTypes,
-  call
+  call,
+  isSharingHierarchyConflictPendingError,
+  isSharingHierarchyConflictUserAbortError,
+  shareHierarchyForceRequestOptions,
+  type SharingHierarchyConflict
 } from '@ownclouders/web-client'
 import {
   useCapabilityStore,
@@ -160,7 +164,9 @@ import {
   useSpacesStore,
   useConfigStore,
   useSharesStore,
-  useUserStore
+  useUserStore,
+  useSharingHierarchyConflictsConfirm,
+  useSharingHierarchyConflictInform
 } from '@ownclouders/web-pkg'
 
 import { computed, defineComponent, inject, ref, unref, watch, onMounted, nextTick, Ref } from 'vue'
@@ -218,6 +224,9 @@ export default defineComponent({
     const sharesStore = useSharesStore()
     const { addShare } = sharesStore
     const { collaboratorShares } = storeToRefs(sharesStore)
+
+    const confirmSharingHierarchyConflicts = useSharingHierarchyConflictsConfirm()
+    const informSharingHierarchyConflict = useSharingHierarchyConflictInform()
 
     const searchQuery = ref('')
     const searchInProgress = ref(false)
@@ -377,46 +386,97 @@ export default defineComponent({
       const savePromises: Promise<void>[] = []
       const errors: { displayName: string; error: Error }[] = []
       const addedShares: CollaboratorShare[] = []
+      const pendingForceShares: {
+        displayName: string
+        conflict: SharingHierarchyConflict
+        addShareParams: Parameters<typeof addShare>[0]
+      }[] = []
+
+      const finishAddedShare = (share: CollaboratorShare) => {
+        addedShares.push(share)
+
+        if (unref(notifyEnabled)) {
+          clientService.httpAuthenticated.get(
+            `/ocs/v1.php/apps/files_sharing/api/v1/shares/${share.id}/notify`
+          ) as any
+        }
+      }
 
       unref(selectedCollaborators).forEach(({ id, shareType, displayName }) => {
         const type = getRecipientType(shareType)
+        const addShareParams = {
+          clientService,
+          space: unref(space),
+          resource: unref(resource),
+          options: {
+            roles: [unref(selectedRole).id],
+            expirationDateTime: unref(expirationDate),
+            recipients: [
+              {
+                objectId: id,
+                '@libre.graph.recipient.type': type
+              }
+            ]
+          }
+        }
 
         savePromises.push(
           saveQueue.add(async () => {
             try {
               const share = await addShare({
-                clientService,
-                space: unref(space),
-                resource: unref(resource),
-                options: {
-                  roles: [unref(selectedRole).id],
-                  expirationDateTime: unref(expirationDate),
-                  recipients: [
-                    {
-                      objectId: id,
-                      '@libre.graph.recipient.type': type
-                    }
-                  ]
-                }
+                ...addShareParams,
+                informSharingHierarchyConflict,
+                deferSharingHierarchyConflictConfirm: true
               })
 
-              addedShares.push(share)
-
-              if (unref(notifyEnabled)) {
-                clientService.httpAuthenticated.get(
-                  `/ocs/v1.php/apps/files_sharing/api/v1/shares/${share.id}/notify`
-                ) as any
-              }
+              finishAddedShare(share)
             } catch (error) {
+              if (isSharingHierarchyConflictPendingError(error)) {
+                pendingForceShares.push({
+                  displayName,
+                  conflict: error.conflict,
+                  addShareParams
+                })
+                return
+              }
+              if (isSharingHierarchyConflictUserAbortError(error)) {
+                return
+              }
               console.error(error)
-              errors.push({ displayName, error })
+              errors.push({ displayName, error: error as Error })
               throw error
             }
           })
         )
       })
 
-      const results = await Promise.allSettled(savePromises)
+      await Promise.allSettled(savePromises)
+
+      if (pendingForceShares.length > 0) {
+        const proceed = await confirmSharingHierarchyConflicts(
+          pendingForceShares.map(({ conflict }) => conflict)
+        )
+
+        if (proceed) {
+          for (const { displayName, addShareParams } of pendingForceShares) {
+            try {
+              const share = await addShare({
+                ...addShareParams,
+                informSharingHierarchyConflict,
+                graphRequestOptions: shareHierarchyForceRequestOptions()
+              })
+
+              finishAddedShare(share)
+            } catch (error) {
+              if (isSharingHierarchyConflictUserAbortError(error)) {
+                continue
+              }
+              console.error(error)
+              errors.push({ displayName, error: error as Error })
+            }
+          }
+        }
+      }
 
       if (isProjectSpaceResource(unref(resource))) {
         const updatedSpace = await clientService.graphAuthenticated.drives.getDrive(
@@ -427,7 +487,7 @@ export default defineComponent({
         upsertSpace(updatedSpace)
       }
 
-      if (results.length !== errors.length) {
+      if (addedShares.length > 0) {
         showMessage({ title: $gettext('Share was added successfully') })
       }
 

--- a/packages/web-app-files/src/components/SideBar/Shares/Collaborators/ListItem.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/Collaborators/ListItem.vue
@@ -66,6 +66,7 @@
             <template v-else>
               <div v-if="modifiable" class="oc-flex oc-flex-nowrap oc-flex-middle">
                 <role-dropdown
+                  ref="roleDropdownRef"
                   :dom-selector="shareDomSelector"
                   :existing-share-role="share.role"
                   :existing-share-permissions="share.permissions"
@@ -128,7 +129,13 @@ import { DateTime } from 'luxon'
 
 import EditDropdown from './EditDropdown.vue'
 import RoleDropdown from './RoleDropdown.vue'
-import { CollaboratorShare, ShareRole, ShareTypes } from '@ownclouders/web-client'
+import {
+  CollaboratorShare,
+  ShareRole,
+  ShareTypes,
+  isSharingHierarchyConflictRemoveShareError,
+  isSharingHierarchyConflictUserAbortError
+} from '@ownclouders/web-client'
 import {
   queryItemAsString,
   useMessages,
@@ -136,10 +143,12 @@ import {
   useSpacesStore,
   useUserStore,
   useSharesStore,
-  useConfigStore
+  useConfigStore,
+  useSharingHierarchyConflictConfirm,
+  useSharingHierarchyConflictInform
 } from '@ownclouders/web-pkg'
 import { Resource, extractDomSelector } from '@ownclouders/web-client'
-import { computed, defineComponent, inject, PropType, Ref, unref } from 'vue'
+import { computed, defineComponent, inject, PropType, Ref, ref, unref } from 'vue'
 import { formatDateFromDateTime } from '@ownclouders/web-pkg'
 import { useClientService } from '@ownclouders/web-pkg'
 import { RouteLocationNamedRaw } from 'vue-router'
@@ -204,7 +213,15 @@ export default defineComponent({
 
     const sharesStore = useSharesStore()
     const { graphRoles } = storeToRefs(sharesStore)
-    const { updateShare } = sharesStore
+    const { updateShare, deleteShare } = sharesStore
+    const confirmSharingHierarchyConflict = useSharingHierarchyConflictConfirm({
+      introVariant: 'update-share'
+    })
+    const informSharingHierarchyConflict = useSharingHierarchyConflictInform()
+    const informRoleUpdateHierarchyConflict = useSharingHierarchyConflictInform({
+      offerRemoveShare: true
+    })
+    const roleDropdownRef = ref<InstanceType<typeof RoleDropdown> | null>(null)
     const { upsertSpace } = useSpacesStore()
 
     const { user } = storeToRefs(userStore)
@@ -235,7 +252,9 @@ export default defineComponent({
     }
     const notifyShare = async () => {
       try {
-        const resp = await clientService.httpAuthenticated.get(`/ocs/v1.php/apps/files_sharing/api/v1/shares/${props.share.id}/notify`) as any
+        const resp = (await clientService.httpAuthenticated.get(
+          `/ocs/v1.php/apps/files_sharing/api/v1/shares/${props.share.id}/notify`
+        )) as any
         showMessage({
           title: $gettext(`Reminder sent to ${resp.data.recipients[0]}`)
         })
@@ -248,6 +267,10 @@ export default defineComponent({
       }
     }
 
+    const revertRoleDropdown = () => {
+      roleDropdownRef.value?.revertToExistingRole?.()
+    }
+
     const sharedViaTooltip = computed(() =>
       $gettext('Shared via the parent folder "%{sharedParentDir}"', {
         sharedParentDir: unref(sharedParentDir)
@@ -257,6 +280,12 @@ export default defineComponent({
       resource: inject<Ref<Resource>>('resource'),
       space: inject<Ref<SpaceResource>>('space'),
       updateShare,
+      deleteShare,
+      confirmSharingHierarchyConflict,
+      informSharingHierarchyConflict,
+      informRoleUpdateHierarchyConflict,
+      roleDropdownRef,
+      revertRoleDropdown,
       user,
       clientService,
       cernFeatures,
@@ -378,44 +407,50 @@ export default defineComponent({
 
     async shareRoleChanged(role: ShareRole) {
       const expirationDateTime = this.share.expirationDateTime
-      try {
-        await this.saveShareChanges({ role, expirationDateTime })
-      } catch (e) {
-        console.error(e)
-        this.showErrorMessage({
-          title: this.$gettext('Failed to apply new permissions'),
-          errors: [e]
-        })
-      }
+      await this.saveShareChanges({
+        role,
+        expirationDateTime,
+        offerRemoveShareOnConflict: !this.share.indirect
+      })
     },
 
     async shareExpirationChanged({ expirationDateTime }: { expirationDateTime: string }) {
       const role = this.share.role
-      try {
-        await this.saveShareChanges({ role, expirationDateTime })
-      } catch (e) {
-        console.error(e)
-        this.showErrorMessage({
-          title: this.$gettext('Failed to apply expiration date'),
-          errors: [e]
-        })
+      await this.saveShareChanges({ role, expirationDateTime })
+    },
+
+    handleShareConflictError(error: Error, title: string) {
+      if (isSharingHierarchyConflictUserAbortError(error)) {
+        this.revertRoleDropdown()
+        return
       }
+      console.error(error)
+      this.revertRoleDropdown()
+      this.showErrorMessage({ title, errors: [error] })
     },
 
     async saveShareChanges({
       role,
-      expirationDateTime
+      expirationDateTime,
+      offerRemoveShareOnConflict = false
     }: {
       role: ShareRole
       expirationDateTime?: string
+      offerRemoveShareOnConflict?: boolean
     }) {
+      const informSharingHierarchyConflict = offerRemoveShareOnConflict
+        ? this.informRoleUpdateHierarchyConflict
+        : this.informSharingHierarchyConflict
+
       try {
         await this.updateShare({
           clientService: this.$clientService,
           space: this.space,
           resource: this.resource,
           collaboratorShare: this.share,
-          options: { roles: [role.id], expirationDateTime }
+          options: { roles: [role.id], expirationDateTime },
+          confirmSharingHierarchyConflict: this.confirmSharingHierarchyConflict,
+          informSharingHierarchyConflict
         })
 
         if (isProjectSpaceResource(this.resource)) {
@@ -427,11 +462,28 @@ export default defineComponent({
 
         this.showMessage({ title: this.$gettext('Share successfully changed') })
       } catch (e) {
-        console.error(e)
-        this.showErrorMessage({
-          title: this.$gettext('Error while editing the share.'),
-          errors: [e]
-        })
+        if (isSharingHierarchyConflictRemoveShareError(e)) {
+          try {
+            await this.deleteShare({
+              clientService: this.clientService,
+              space: this.space,
+              resource: this.resource,
+              collaboratorShare: this.share,
+              loadIndicators: true,
+              confirmSharingHierarchyConflict: this.confirmSharingHierarchyConflict,
+              informSharingHierarchyConflict: this.informSharingHierarchyConflict
+            })
+            this.showMessage({ title: this.$gettext('Share successfully removed') })
+          } catch (deleteError) {
+            this.handleShareConflictError(
+              deleteError,
+              this.$gettext('Error while removing the share.')
+            )
+          }
+          return
+        }
+
+        this.handleShareConflictError(e, this.$gettext('Error while editing the share.'))
       }
     }
   }

--- a/packages/web-app-files/src/components/SideBar/Shares/Collaborators/RoleDropdown.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/Collaborators/RoleDropdown.vue
@@ -158,30 +158,28 @@ export default defineComponent({
       return unref(roles)
     })
 
-    let initialSelectedRole: ShareRole
     const hasExistingShareRole = computed(() => !!props.existingShareRole)
     const hasExistingSharePermissions = computed(() => !!props.existingSharePermissions.length)
     const isDisabledRole = computed(
       () => !unref(hasExistingShareRole) && unref(hasExistingSharePermissions)
     )
-    switch (true) {
-      // if no role is set and no permissions are set, we use the first available role as the default
-      case !unref(hasExistingShareRole) && !unref(hasExistingSharePermissions):
-        initialSelectedRole = unref(availableRoles)[0]
-        break
-      // in the rare case that a role is disabled and permissions are set aka a disabled unified role ...
-      case unref(isDisabledRole):
-        // ... we need to create a fake role as an indicator that the permissions are custom
-        initialSelectedRole = {
-          displayName: $gettext('Custom permissions')
-        }
-        break
-      default:
-        initialSelectedRole = props.existingShareRole
-        break
+
+    // if a role is set, use it; if permissions are set without a role (a disabled unified role),
+    // show a fake role as an indicator that the permissions are custom; otherwise default to the
+    // first available role
+    const resolveRoleForExistingState = (): ShareRole => {
+      if (unref(hasExistingShareRole)) {
+        return props.existingShareRole!
+      }
+
+      if (unref(isDisabledRole)) {
+        return { displayName: $gettext('Custom permissions') }
+      }
+
+      return unref(availableRoles)[0]
     }
 
-    const selectedRole = ref<ShareRole>(initialSelectedRole)
+    const selectedRole = ref<ShareRole>(resolveRoleForExistingState())
     const isSelectedRole = (role: ShareRole) => {
       return unref(selectedRole).id === role.id
     }
@@ -190,6 +188,23 @@ export default defineComponent({
       selectedRole.value = role
       emit('optionChange', unref(selectedRole))
     }
+
+    const revertToExistingRole = () => {
+      if (props.mode !== 'edit') {
+        return
+      }
+
+      selectedRole.value = resolveRoleForExistingState()
+    }
+
+    watch(
+      () => props.existingShareRole,
+      (role) => {
+        if (props.mode === 'edit' && role) {
+          selectedRole.value = role
+        }
+      }
+    )
 
     watch(
       () => props.isExternal,
@@ -211,6 +226,7 @@ export default defineComponent({
       availableRoles,
       isSelectedRole,
       selectRole,
+      revertToExistingRole,
       isDisabledRole
     }
   },

--- a/packages/web-app-files/src/components/SideBar/Shares/FileShares.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/FileShares.vue
@@ -108,7 +108,9 @@ import {
   useConfigStore,
   useSharesStore,
   useResourcesStore,
-  useCanShare
+  useCanShare,
+  useSharingHierarchyConflictConfirm,
+  useSharingHierarchyConflictInform
 } from '@ownclouders/web-pkg'
 import { isLocationSharesActive } from '@ownclouders/web-pkg'
 import { textUtils } from '../../../helpers/textUtils'
@@ -122,7 +124,8 @@ import {
   Resource,
   SpaceResource,
   CollaboratorShare,
-  isSpaceResource
+  isSpaceResource,
+  isSharingHierarchyConflictUserAbortError
 } from '@ownclouders/web-client'
 import { getSharedAncestorRoute } from '@ownclouders/web-pkg'
 import CopyPrivateLink from '../../Shares/CopyPrivateLink.vue'
@@ -152,6 +155,9 @@ export default defineComponent({
 
     const sharesStore = useSharesStore()
     const { addShare, deleteShare } = sharesStore
+
+    const confirmSharingHierarchyConflict = useSharingHierarchyConflictConfirm()
+    const informSharingHierarchyConflict = useSharingHierarchyConflictInform()
 
     const { user } = storeToRefs(userStore)
 
@@ -208,6 +214,8 @@ export default defineComponent({
     return {
       addShare,
       deleteShare,
+      confirmSharingHierarchyConflict,
+      informSharingHierarchyConflict,
       user,
       resource,
       space,
@@ -335,12 +343,17 @@ export default defineComponent({
             clientService: this.$clientService,
             space: this.space,
             resource: this.resource,
-            options: {}
+            options: {},
+            confirmSharingHierarchyConflict: this.confirmSharingHierarchyConflict,
+            informSharingHierarchyConflict: this.informSharingHierarchyConflict
           })
           this.showMessage({
             title: this.$gettext('Access was denied successfully')
           })
         } catch (e) {
+          if (isSharingHierarchyConflictUserAbortError(e)) {
+            return
+          }
           console.error(e)
           this.showErrorMessage({
             title: this.$gettext('Failed to deny access'),
@@ -356,12 +369,17 @@ export default defineComponent({
             collaboratorShare: isSpaceResource(this.resource)
               ? this.getDeniedSpaceMember(share)
               : this.getDeniedShare(share),
-            loadIndicators: false
+            loadIndicators: false,
+            confirmSharingHierarchyConflict: this.confirmSharingHierarchyConflict,
+            informSharingHierarchyConflict: this.informSharingHierarchyConflict
           })
           this.showMessage({
             title: this.$gettext('Access was granted successfully')
           })
         } catch (e) {
+          if (isSharingHierarchyConflictUserAbortError(e)) {
+            return
+          }
           console.error(e)
           this.showErrorMessage({
             title: this.$gettext('Failed to grant access'),
@@ -388,7 +406,9 @@ export default defineComponent({
               space: this.space,
               resource: this.resource,
               collaboratorShare,
-              loadIndicators
+              loadIndicators,
+              confirmSharingHierarchyConflict: this.confirmSharingHierarchyConflict,
+              informSharingHierarchyConflict: this.informSharingHierarchyConflict
             })
 
             this.showMessage({
@@ -398,6 +418,9 @@ export default defineComponent({
               this.removeResources([{ id: lastShareId }] as Resource[])
             }
           } catch (error) {
+            if (isSharingHierarchyConflictUserAbortError(error)) {
+              return
+            }
             console.error(error)
             this.showErrorMessage({
               title: this.$gettext('Failed to remove share'),

--- a/packages/web-app-files/tests/unit/components/SideBar/Shares/Collaborators/InviteCollaborator/InviteCollaboratorForm.spec.ts
+++ b/packages/web-app-files/tests/unit/components/SideBar/Shares/Collaborators/InviteCollaborator/InviteCollaboratorForm.spec.ts
@@ -110,6 +110,19 @@ describe('InviteCollaboratorForm', () => {
 
       expect(wrapper.vm.autocompleteResults.length).toBe(1)
     })
+    it('does not filter out existing indirect shares, since their role can still be increased', async () => {
+      const { wrapper } = getWrapper({
+        users: [{ id: '2' } as User],
+        groups: [{ id: '3' }],
+        existingCollaborators: [
+          mock<CollaboratorShare>({ sharedWith: { id: '2' }, indirect: true })
+        ]
+      })
+
+      await wrapper.vm.fetchRecipientsTask.last
+
+      expect(wrapper.vm.autocompleteResults.length).toBe(2)
+    })
   })
   describe('share action', () => {
     it('clicking the invite-sharees button calls the "share"-action', async () => {

--- a/packages/web-app-files/tests/unit/components/SideBar/Shares/Collaborators/ListItem.spec.ts
+++ b/packages/web-app-files/tests/unit/components/SideBar/Shares/Collaborators/ListItem.spec.ts
@@ -145,18 +145,16 @@ describe('Collaborator ListItem component', () => {
       const resource = mock<SpaceResource>({ driveType: 'project' })
       vi.spyOn(console, 'error').mockImplementation(() => undefined)
       const { wrapper } = createWrapper()
-      vi.spyOn(wrapper.vm, 'saveShareChanges').mockImplementation(() => {
-        throw new Error()
-      })
+      const sharesStore = useSharesStore()
+      vi.mocked(sharesStore.updateShare).mockRejectedValueOnce(new Error('update failed'))
       wrapper.findComponent<typeof RoleDropdown>('role-dropdown-stub').vm.$emit('optionChange', {
-        share: getShareMock({ shareType: ShareTypes.user.value }),
-        resource
+        id: 'editor',
+        displayName: 'Can edit'
       })
 
       await nextTicks(4)
 
-      const sharesStore = useSharesStore()
-      expect(sharesStore.updateShare).not.toHaveBeenCalled()
+      expect(sharesStore.updateShare).toHaveBeenCalled()
       const messagesStore = useMessages()
       expect(messagesStore.showErrorMessage).toHaveBeenCalled()
     })
@@ -172,19 +170,21 @@ describe('Collaborator ListItem component', () => {
       const sharesStore = useSharesStore()
       expect(sharesStore.updateShare).toHaveBeenCalled()
     })
-    it('shows a message on error', () => {
+    it('shows a message on error', async () => {
       vi.spyOn(console, 'error').mockImplementation(() => undefined)
       const { wrapper } = createWrapper()
-      vi.spyOn(wrapper.vm, 'saveShareChanges').mockImplementation(() => {
-        throw new Error()
-      })
+      const sharesStore = useSharesStore()
+      vi.mocked(sharesStore.updateShare).mockRejectedValueOnce(new Error('update failed'))
+
       wrapper
         .findComponent<typeof EditDropdown>('edit-dropdown-stub')
         .vm.$emit('expirationDateChanged', {
           shareExpirationChanged: new Date()
         })
-      const sharesStore = useSharesStore()
-      expect(sharesStore.updateShare).not.toHaveBeenCalled()
+
+      await nextTicks(4)
+
+      expect(sharesStore.updateShare).toHaveBeenCalled()
       const messagesStore = useMessages()
       expect(messagesStore.showErrorMessage).toHaveBeenCalled()
     })

--- a/packages/web-app-files/tests/unit/components/SideBar/Shares/Collaborators/RoleDropdown.spec.ts
+++ b/packages/web-app-files/tests/unit/components/SideBar/Shares/Collaborators/RoleDropdown.spec.ts
@@ -47,6 +47,20 @@ describe('RoleDropdown', () => {
     await wrapper.find(selectors.roleButton).trigger('click')
     expect(wrapper.emitted('optionChange')).toBeTruthy()
   })
+  it('reverts to the existing role after a failed edit selection', async () => {
+    const existingShareRole = mock<ShareRole>({ id: 'viewer', displayName: 'Can view' })
+    const { wrapper } = getWrapper({
+      mountType: shallowMount,
+      mode: 'edit',
+      existingShareRole
+    })
+    ;(wrapper.vm.$refs.rolesDrop as any).tippy = { hide: vi.fn() }
+    await wrapper.findAll(selectors.roleButton).at(1)?.trigger('click')
+    expect(wrapper.vm.selectedRole.displayName).not.toEqual('Can view')
+
+    wrapper.vm.revertToExistingRole()
+    expect(wrapper.vm.selectedRole).toEqual(existingShareRole)
+  })
   it('renders a button for each available role', () => {
     const { wrapper } = getWrapper({ mountType: shallowMount })
     expect(wrapper.findAll(selectors.roleButton).length).toBe(2)
@@ -71,6 +85,7 @@ function getWrapper({
   existingShareRole = null,
   existingSharePermissions = null,
   isExternal = false,
+  mode = 'create',
   availableInternalShareRoles = [
     mock<ShareRole>({ displayName: 'Can view', description: '' }),
     mock<ShareRole>({ displayName: 'Can edit', description: '' })
@@ -81,6 +96,7 @@ function getWrapper({
   existingShareRole?: ShareRole
   existingSharePermissions?: string[]
   isExternal?: boolean
+  mode?: string
   availableInternalShareRoles?: ShareRole[]
   availableExternalShareRoles?: ShareRole[]
 } = {}) {
@@ -89,7 +105,8 @@ function getWrapper({
       props: {
         existingShareRole,
         existingSharePermissions: existingSharePermissions ?? [],
-        isExternal
+        isExternal,
+        mode
       },
       global: {
         plugins: [

--- a/packages/web-client/src/graph/permissions/permissions.ts
+++ b/packages/web-client/src/graph/permissions/permissions.ts
@@ -101,7 +101,7 @@ export const PermissionsFactory = ({
       permId: string,
       data: Permission,
       graphRoles: Record<string, ShareRole>,
-      requestOptions: GraphRequestOptions
+      requestOptions: GraphRequestOptions = {}
     ): Promise<T> {
       let permission: Permission
 
@@ -137,7 +137,7 @@ export const PermissionsFactory = ({
       }) as T
     },
 
-    async deletePermission(driveId, itemId, permId, requestOptions) {
+    async deletePermission(driveId, itemId, permId, requestOptions: GraphRequestOptions = {}) {
       if (driveId === itemId) {
         await drivesRootApiFactory.deletePermissionSpaceRoot(driveId, permId, requestOptions)
         return
@@ -146,7 +146,13 @@ export const PermissionsFactory = ({
       await drivesPermissionsApiFactory.deletePermission(driveId, itemId, permId, requestOptions)
     },
 
-    async createInvite(driveId, itemId, data, graphRoles, requestOptions) {
+    async createInvite(
+      driveId,
+      itemId,
+      data,
+      graphRoles,
+      requestOptions: GraphRequestOptions = {}
+    ) {
       let permission: Permission | undefined
 
       if (driveId === itemId) {

--- a/packages/web-client/src/graph/sharing/conflict.ts
+++ b/packages/web-client/src/graph/sharing/conflict.ts
@@ -1,0 +1,197 @@
+import axios from 'axios'
+
+/** HTTP header Reva ocgraph reads on invite/update (see `Force` in feat/share-consistency). */
+export const SHARE_HIERARCHY_FORCE_HEADER = 'Force'
+
+export const shareHierarchyForceRequestOptions = (): { headers: Record<string, string> } => ({
+  headers: { [SHARE_HIERARCHY_FORCE_HEADER]: 'true' }
+})
+
+export type SharingHierarchyConflictingShare = {
+  id?: string
+  resourceId?: string
+  path?: string
+  permissionType?: string
+  sharee?: string
+}
+
+export type SharingHierarchyConflict = {
+  kind: 'hierarchy_conflict'
+  errorType: string
+  message: string
+  canForce: boolean
+  conflictingShares?: SharingHierarchyConflictingShare[]
+  raw: unknown
+}
+
+export type ConfirmSharingHierarchyConflict = (
+  conflict: SharingHierarchyConflict
+) => Promise<boolean>
+
+export type InformSharingHierarchyConflict = (
+  conflict: SharingHierarchyConflict
+) => Promise<void>
+
+export class SharingHierarchyConflictCancelledError extends Error {
+  readonly name = 'SharingHierarchyConflictCancelledError'
+
+  constructor() {
+    super('Sharing hierarchy change cancelled')
+  }
+}
+
+export function isSharingHierarchyConflictCancelledError(e: unknown): boolean {
+  return e instanceof SharingHierarchyConflictCancelledError
+}
+
+/** Thrown after the user acknowledges a non-forcible hierarchy conflict (`can_force: false`). */
+export class SharingHierarchyConflictBlockedError extends Error {
+  readonly name = 'SharingHierarchyConflictBlockedError'
+
+  constructor() {
+    super('Sharing hierarchy change blocked')
+  }
+}
+
+export function isSharingHierarchyConflictBlockedError(e: unknown): boolean {
+  return e instanceof SharingHierarchyConflictBlockedError
+}
+
+/** Thrown when the user chooses to remove a redundant direct share from an inform dialog. */
+export class SharingHierarchyConflictRemoveShareError extends Error {
+  readonly name = 'SharingHierarchyConflictRemoveShareError'
+
+  constructor() {
+    super('Sharing hierarchy change requests share removal')
+  }
+}
+
+export function isSharingHierarchyConflictRemoveShareError(e: unknown): boolean {
+  return e instanceof SharingHierarchyConflictRemoveShareError
+}
+
+/** User dismissed or was blocked; do not show a mutation failure toast. */
+export function isSharingHierarchyConflictUserAbortError(e: unknown): boolean {
+  return (
+    isSharingHierarchyConflictCancelledError(e) || isSharingHierarchyConflictBlockedError(e)
+  )
+}
+
+/** Thrown when `deferSharingHierarchyConflictConfirm` is set and the caller should batch confirmations. */
+export class SharingHierarchyConflictPendingError extends Error {
+  readonly name = 'SharingHierarchyConflictPendingError'
+
+  constructor(readonly conflict: SharingHierarchyConflict) {
+    super(conflict.message || conflict.errorType || 'Sharing hierarchy conflict')
+  }
+}
+
+export function isSharingHierarchyConflictPendingError(
+  e: unknown
+): e is SharingHierarchyConflictPendingError {
+  return e instanceof SharingHierarchyConflictPendingError
+}
+
+function asRecord(v: unknown): Record<string, unknown> | null {
+  if (!v || typeof v !== 'object' || Array.isArray(v)) {
+    return null
+  }
+  return v as Record<string, unknown>
+}
+
+function pickPayload(data: unknown): Record<string, unknown> | null {
+  const root = asRecord(data)
+  if (!root) {
+    return null
+  }
+  if ('error' in root) {
+    return asRecord(root.error)
+  }
+  return root
+}
+
+function parseConflictingShare(value: unknown): SharingHierarchyConflictingShare | null {
+  const record = asRecord(value)
+  if (!record) {
+    return null
+  }
+
+  const share: SharingHierarchyConflictingShare = {}
+  if (typeof record.id === 'string') {
+    share.id = record.id
+  }
+  if (typeof record.resource_id === 'string') {
+    share.resourceId = record.resource_id
+  }
+  if (typeof record.path === 'string') {
+    share.path = record.path
+  }
+  if (typeof record.permission_type === 'string') {
+    share.permissionType = record.permission_type
+  }
+  if (typeof record.sharee === 'string') {
+    share.sharee = record.sharee
+  }
+
+  return Object.keys(share).length > 0 ? share : null
+}
+
+export function parseSharingHierarchyConflictPayload(
+  status: number | undefined,
+  data: unknown
+): SharingHierarchyConflict | null {
+  if (status !== 409) {
+    return null
+  }
+
+  let parsed: unknown = data
+  if (typeof data === 'string') {
+    try {
+      parsed = JSON.parse(data)
+    } catch {
+      return null
+    }
+  }
+
+  const payload = pickPayload(parsed)
+  if (!payload) {
+    return null
+  }
+
+  const errorType = typeof payload.error_type === 'string' ? payload.error_type : ''
+  const message = typeof payload.message === 'string' ? payload.message : ''
+  if (!errorType) {
+    return null
+  }
+
+  const canForce = payload.can_force === true
+  let conflictingShares: SharingHierarchyConflictingShare[] | undefined
+  if (Array.isArray(payload.conflicting_shares)) {
+    conflictingShares = payload.conflicting_shares
+      .map(parseConflictingShare)
+      .filter((share): share is SharingHierarchyConflictingShare => share !== null)
+    if (conflictingShares.length === 0) {
+      conflictingShares = undefined
+    }
+  }
+
+  return {
+    kind: 'hierarchy_conflict',
+    errorType,
+    message,
+    canForce,
+    conflictingShares,
+    raw: parsed
+  }
+}
+
+/**
+ * Parses a Graph/Axios error response for ADR-0005 hierarchy conflicts (HTTP 409 + JSON body).
+ * Matches Reva `pkg/sharehierarchy.HierarchyConflictError` on feat/share-consistency.
+ */
+export function parseSharingHierarchyConflict(error: unknown): SharingHierarchyConflict | null {
+  if (!axios.isAxiosError(error)) {
+    return null
+  }
+  return parseSharingHierarchyConflictPayload(error.response?.status, error.response?.data)
+}

--- a/packages/web-client/src/index.ts
+++ b/packages/web-client/src/index.ts
@@ -6,6 +6,9 @@ import { WebDAV, webdav } from './webdav'
 export * from './errors'
 export * from './helpers'
 export * from './utils'
+export * from './graph/sharing/conflict'
+
+export type { GraphRequestOptions } from './graph/types'
 
 export { graph, ocs, webdav }
 

--- a/packages/web-client/tests/unit/graph/sharing/conflict.spec.ts
+++ b/packages/web-client/tests/unit/graph/sharing/conflict.spec.ts
@@ -1,0 +1,224 @@
+import { describe, expect, it } from 'vitest'
+import { AxiosError } from 'axios'
+import {
+  SHARE_HIERARCHY_FORCE_HEADER,
+  SharingHierarchyConflictBlockedError,
+  SharingHierarchyConflictCancelledError,
+  SharingHierarchyConflictPendingError,
+  SharingHierarchyConflictRemoveShareError,
+  isSharingHierarchyConflictBlockedError,
+  isSharingHierarchyConflictCancelledError,
+  isSharingHierarchyConflictPendingError,
+  isSharingHierarchyConflictRemoveShareError,
+  isSharingHierarchyConflictUserAbortError,
+  parseSharingHierarchyConflict,
+  parseSharingHierarchyConflictPayload,
+  shareHierarchyForceRequestOptions
+} from '../../../../src/graph/sharing/conflict'
+
+function axios409(data: unknown): AxiosError {
+  return new AxiosError(
+    'Conflict',
+    'ERR_BAD_REQUEST',
+    undefined,
+    {},
+    {
+      status: 409,
+      statusText: 'Conflict',
+      data,
+      headers: {},
+      config: {} as any
+    }
+  )
+}
+
+describe('shareHierarchyForceRequestOptions', () => {
+  it('uses the Reva Force header from feat/share-consistency', () => {
+    expect(shareHierarchyForceRequestOptions()).toEqual({
+      headers: { [SHARE_HIERARCHY_FORCE_HEADER]: 'true' }
+    })
+    expect(SHARE_HIERARCHY_FORCE_HEADER).toBe('Force')
+  })
+})
+
+describe('parseSharingHierarchyConflictPayload', () => {
+  it.each([
+    {
+      name: 'child conflict with conflicting shares',
+      data: {
+        error_type: 'child_conflict',
+        message: 'Child shares will be removed',
+        can_force: true,
+        conflicting_shares: [
+          {
+            id: 'share-1',
+            resource_id: 'storage!item',
+            path: '/project/sub',
+            permission_type: 'read'
+          }
+        ]
+      },
+      expected: {
+        kind: 'hierarchy_conflict',
+        errorType: 'child_conflict',
+        message: 'Child shares will be removed',
+        canForce: true,
+        conflictingShares: [
+          {
+            id: 'share-1',
+            resourceId: 'storage!item',
+            path: '/project/sub',
+            permissionType: 'read'
+          }
+        ]
+      }
+    },
+    {
+      name: 'parent conflict',
+      data: {
+        error_type: 'parent_conflict',
+        message: 'Already shared through parent',
+        can_force: false
+      },
+      expected: {
+        kind: 'hierarchy_conflict',
+        errorType: 'parent_conflict',
+        message: 'Already shared through parent',
+        canForce: false,
+        conflictingShares: undefined
+      }
+    },
+    {
+      name: 'omitted can_force',
+      data: {
+        error_type: 'parent_conflict',
+        message: 'Blocked'
+      },
+      expected: {
+        kind: 'hierarchy_conflict',
+        errorType: 'parent_conflict',
+        message: 'Blocked',
+        canForce: false,
+        conflictingShares: undefined
+      }
+    }
+  ])('parses $name', ({ data, expected }) => {
+    const r = parseSharingHierarchyConflictPayload(409, data)
+    expect(r).toMatchObject(expected)
+    expect(r?.raw).toBeDefined()
+  })
+
+  it('returns null for non-409', () => {
+    expect(
+      parseSharingHierarchyConflictPayload(400, {
+        error_type: 'parent_conflict',
+        message: 'y'
+      })
+    ).toBeNull()
+  })
+
+  it('returns null for legacy Gerard payload shape', () => {
+    expect(
+      parseSharingHierarchyConflictPayload(409, {
+        code: 'SHARING_HIERARCHY_CONFLICT',
+        message: 'legacy',
+        can_force: true
+      })
+    ).toBeNull()
+  })
+
+  it('parses string JSON body', () => {
+    const raw =
+      '{"error_type":"child_conflict","message":"M","can_force":true,"conflicting_shares":[{"id":"1","path":"/a"}]}'
+    const r = parseSharingHierarchyConflictPayload(409, raw)
+    expect(r?.errorType).toBe('child_conflict')
+    expect(r?.canForce).toBe(true)
+    expect(r?.conflictingShares).toEqual([{ id: '1', path: '/a' }])
+  })
+
+  it('parses conflicting share fields from Reva', () => {
+    const r = parseSharingHierarchyConflictPayload(409, {
+      error_type: 'parent_conflict',
+      message: 'Already shared',
+      can_force: false,
+      conflicting_shares: [
+        {
+          id: 'share-1',
+          resource_id: 'storage!item',
+          path: '/folder/doc.txt',
+          permission_type: 'ReadWrite',
+          sharee: 'tstcbsa2'
+        }
+      ]
+    })
+
+    expect(r?.conflictingShares).toEqual([
+      {
+        id: 'share-1',
+        resourceId: 'storage!item',
+        path: '/folder/doc.txt',
+        permissionType: 'ReadWrite',
+        sharee: 'tstcbsa2'
+      }
+    ])
+  })
+})
+
+describe('parseSharingHierarchyConflict', () => {
+  it('returns null for non-axios errors', () => {
+    expect(parseSharingHierarchyConflict(new Error('x'))).toBeNull()
+  })
+
+  it('extracts conflict from axios 409', () => {
+    const err = axios409({
+      error_type: 'child_conflict',
+      message: 'M',
+      can_force: true
+    })
+    expect(parseSharingHierarchyConflict(err)?.message).toBe('M')
+    expect(parseSharingHierarchyConflict(err)?.errorType).toBe('child_conflict')
+  })
+})
+
+describe('SharingHierarchyConflictPendingError', () => {
+  it('is detected by type guard', () => {
+    const conflict = {
+      kind: 'hierarchy_conflict' as const,
+      errorType: 'child_conflict',
+      message: 'warn',
+      canForce: true,
+      raw: {}
+    }
+    const err = new SharingHierarchyConflictPendingError(conflict)
+    expect(isSharingHierarchyConflictPendingError(err)).toBe(true)
+    expect(isSharingHierarchyConflictPendingError(new Error('x'))).toBe(false)
+    expect(err.conflict).toBe(conflict)
+  })
+})
+
+describe('SharingHierarchyConflict user abort errors', () => {
+  it('detects blocked and cancelled errors', () => {
+    expect(isSharingHierarchyConflictBlockedError(new SharingHierarchyConflictBlockedError())).toBe(
+      true
+    )
+    expect(
+      isSharingHierarchyConflictCancelledError(new SharingHierarchyConflictCancelledError())
+    ).toBe(true)
+    expect(
+      isSharingHierarchyConflictUserAbortError(new SharingHierarchyConflictBlockedError())
+    ).toBe(true)
+    expect(
+      isSharingHierarchyConflictUserAbortError(new SharingHierarchyConflictCancelledError())
+    ).toBe(true)
+    expect(isSharingHierarchyConflictUserAbortError(new Error('x'))).toBe(false)
+  })
+
+  it('detects remove share errors separately from user abort', () => {
+    expect(
+      isSharingHierarchyConflictRemoveShareError(new SharingHierarchyConflictRemoveShareError())
+    ).toBe(true)
+    expect(
+      isSharingHierarchyConflictUserAbortError(new SharingHierarchyConflictRemoveShareError())
+    ).toBe(false)
+  })
+})

--- a/packages/web-pkg/src/components/Modals/SharingHierarchyConflictModal.vue
+++ b/packages/web-pkg/src/components/Modals/SharingHierarchyConflictModal.vue
@@ -1,0 +1,163 @@
+<template>
+  <div class="sharing-hierarchy-conflict-modal">
+    <p class="sharing-hierarchy-conflict-modal-intro oc-mb-s" v-text="intro" />
+    <div
+      v-if="groups.length"
+      class="sharing-hierarchy-conflict-modal-list"
+      data-testid="sharing-hierarchy-conflict-list"
+    >
+      <div
+        v-for="group in groups"
+        :key="group.shareeKey"
+        class="sharing-hierarchy-conflict-modal-group oc-mb-s"
+      >
+        <p
+          class="sharing-hierarchy-conflict-modal-sharee oc-text-bold oc-m-rm"
+          v-text="sharedWithLabel(group)"
+        />
+        <ul class="sharing-hierarchy-conflict-modal-entries oc-pl-m oc-my-s">
+          <li
+            v-for="entry in group.entries"
+            :key="entry.key"
+            class="sharing-hierarchy-conflict-modal-entry"
+            v-text="entryLine(entry)"
+          />
+        </ul>
+      </div>
+    </div>
+    <div class="oc-flex oc-flex-right oc-flex-middle oc-mt-m">
+      <div class="oc-modal-body-actions-grid">
+        <oc-button
+          class="oc-modal-body-actions-cancel"
+          appearance="outline"
+          variation="passive"
+          @click="onCancel"
+        >
+          {{ cancelLabel }}
+        </oc-button>
+        <oc-button
+          v-if="mode === 'confirm' || mode === 'inform-remove'"
+          class="oc-modal-body-actions-confirm oc-ml-s"
+          appearance="filled"
+          :variation="mode === 'inform-remove' ? 'danger' : 'primary'"
+          @click="onConfirm"
+        >
+          {{ confirmLabel }}
+        </oc-button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import type { ShareRole, SharingHierarchyConflict } from '@ownclouders/web-client'
+import { computed, defineComponent, PropType, toRef, unref } from 'vue'
+import { useGettext } from 'vue3-gettext'
+import { Modal, useModals } from '../../composables/piniaStores/modals'
+import {
+  collectConflictingShares,
+  getSharingHierarchyConflictIntro,
+  groupConflictingSharesBySharee,
+  type ShareeConflictGroup,
+  type SharingHierarchyConflictIntroVariant
+} from '../../composables/shares/sharingHierarchyConflictDisplay'
+
+export type SharingHierarchyConflictModalResult = boolean | 'remove'
+
+export default defineComponent({
+  name: 'SharingHierarchyConflictModal',
+  props: {
+    modal: { type: Object as PropType<Modal>, required: true },
+    conflicts: {
+      type: Array as PropType<SharingHierarchyConflict[]>,
+      required: true
+    },
+    mode: {
+      type: String as PropType<'confirm' | 'inform' | 'inform-remove'>,
+      default: 'confirm'
+    },
+    introVariant: {
+      type: String as PropType<SharingHierarchyConflictIntroVariant>,
+      default: 'default'
+    },
+    resourcePath: {
+      type: String,
+      default: undefined
+    },
+    graphRoles: {
+      type: Object as PropType<Record<string, ShareRole>>,
+      default: () => ({})
+    },
+    callbackFn: {
+      type: Function as PropType<(result: SharingHierarchyConflictModalResult) => void>,
+      required: true
+    }
+  },
+  setup(props) {
+    const { removeModal } = useModals()
+    const { $gettext } = useGettext()
+
+    const conflicts = toRef(props, 'conflicts')
+
+    const intro = computed(() =>
+      getSharingHierarchyConflictIntro(unref(conflicts), $gettext, props.introVariant)
+    )
+    const groups = computed<ShareeConflictGroup[]>(() =>
+      groupConflictingSharesBySharee(
+        collectConflictingShares(unref(conflicts)),
+        props.resourcePath,
+        props.graphRoles,
+        $gettext
+      )
+    )
+
+    const cancelLabel = computed(() =>
+      props.mode === 'inform' || props.mode === 'inform-remove' ? $gettext('OK') : $gettext('Cancel')
+    )
+    const confirmLabel = computed(() => {
+      if (props.mode === 'inform-remove') {
+        return $gettext('Remove this share')
+      }
+
+      return unref(conflicts).length > 1 ? $gettext('Proceed with all') : $gettext('Proceed anyway')
+    })
+
+    const sharedWithLabel = (group: ShareeConflictGroup) =>
+      $gettext('Shared with %{sharee}:', { sharee: group.shareeLabel })
+
+    const entryLine = (entry: ShareeConflictGroup['entries'][number]) =>
+      `(${entry.permissionLabel}) ${entry.relativePath}`
+
+    const finish = (result: SharingHierarchyConflictModalResult) => {
+      removeModal(props.modal.id)
+      props.callbackFn(result)
+    }
+
+    const onConfirm = () => finish(props.mode === 'inform-remove' ? 'remove' : true)
+    const onCancel = () => finish(false)
+
+    return {
+      intro,
+      groups,
+      cancelLabel,
+      confirmLabel,
+      sharedWithLabel,
+      entryLine,
+      onConfirm,
+      onCancel
+    }
+  }
+})
+</script>
+
+<style lang="scss" scoped>
+.sharing-hierarchy-conflict-modal-list {
+  max-height: 240px;
+  overflow-y: auto;
+  padding-right: var(--oc-space-xsmall);
+}
+
+.sharing-hierarchy-conflict-modal-entry + .sharing-hierarchy-conflict-modal-entry {
+  margin-top: var(--oc-space-xsmall);
+}
+</style>

--- a/packages/web-pkg/src/components/Modals/index.ts
+++ b/packages/web-pkg/src/components/Modals/index.ts
@@ -1,4 +1,5 @@
 export { default as ResourceConflictModal } from './ResourceConflictModal.vue'
+export { default as SharingHierarchyConflictModal } from './SharingHierarchyConflictModal.vue'
 export { default as SpaceMoveInfoModal } from './SpaceMoveInfoModal.vue'
 export { default as EmojiPickerModal } from './EmojiPickerModal.vue'
 export { default as FilePickerModal } from './FilePickerModal.vue'

--- a/packages/web-pkg/src/composables/piniaStores/shares/shares.ts
+++ b/packages/web-pkg/src/composables/piniaStores/shares/shares.ts
@@ -4,7 +4,15 @@ import {
   Share,
   ShareRole,
   ShareTypes,
-  isProjectSpaceResource
+  isProjectSpaceResource,
+  parseSharingHierarchyConflict,
+  shareHierarchyForceRequestOptions,
+  SharingHierarchyConflictBlockedError,
+  SharingHierarchyConflictCancelledError,
+  SharingHierarchyConflictPendingError,
+  type ConfirmSharingHierarchyConflict,
+  type GraphRequestOptions,
+  type InformSharingHierarchyConflict
 } from '@ownclouders/web-client'
 import { defineStore } from 'pinia'
 import { Ref, ref, unref } from 'vue'
@@ -19,6 +27,53 @@ import {
 import { useResourcesStore } from '../resources'
 import { useThemeStore } from '../theme'
 import { Permission, UnifiedRoleDefinition } from '@ownclouders/web-client/graph/generated'
+
+function mergeGraphRequestOptions(
+  base?: GraphRequestOptions,
+  extra?: GraphRequestOptions
+): GraphRequestOptions {
+  return {
+    ...base,
+    ...extra,
+    headers: { ...base?.headers, ...extra?.headers }
+  }
+}
+
+async function withShareHierarchyForceRetry<T>(
+  graphRequestOptions: GraphRequestOptions | undefined,
+  confirmSharingHierarchyConflict: ConfirmSharingHierarchyConflict | undefined,
+  informSharingHierarchyConflict: InformSharingHierarchyConflict | undefined,
+  deferSharingHierarchyConflictConfirm: boolean | undefined,
+  request: (opts?: GraphRequestOptions) => Promise<T>
+): Promise<T> {
+  try {
+    return await request(graphRequestOptions)
+  } catch (e) {
+    const conflict = parseSharingHierarchyConflict(e)
+    if (!conflict) {
+      throw e
+    }
+    if (!conflict.canForce) {
+      if (informSharingHierarchyConflict) {
+        await informSharingHierarchyConflict(conflict)
+      }
+      throw new SharingHierarchyConflictBlockedError()
+    }
+    if (deferSharingHierarchyConflictConfirm) {
+      throw new SharingHierarchyConflictPendingError(conflict)
+    }
+    if (!confirmSharingHierarchyConflict) {
+      throw new SharingHierarchyConflictBlockedError()
+    }
+    const proceed = await confirmSharingHierarchyConflict(conflict)
+    if (!proceed) {
+      throw new SharingHierarchyConflictCancelledError()
+    }
+    return await request(
+      mergeGraphRequestOptions(graphRequestOptions, shareHierarchyForceRequestOptions())
+    )
+  }
+}
 
 export const useSharesStore = defineStore('shares', () => {
   const resourcesStore = useResourcesStore()
@@ -146,9 +201,24 @@ export const useSharesStore = defineStore('shares', () => {
     }
   }
 
-  const addShare = async ({ clientService, space, resource, options }: AddShareOptions) => {
+  const addShare = async ({
+    clientService,
+    space,
+    resource,
+    options,
+    graphRequestOptions,
+    confirmSharingHierarchyConflict,
+    informSharingHierarchyConflict,
+    deferSharingHierarchyConflictConfirm
+  }: AddShareOptions) => {
     const client = clientService.graphAuthenticated.permissions
-    const share = await client.createInvite(space.id, resource.id, options, unref(graphRoles))
+    const share = await withShareHierarchyForceRetry(
+      graphRequestOptions,
+      confirmSharingHierarchyConflict,
+      informSharingHierarchyConflict,
+      deferSharingHierarchyConflictConfirm,
+      (opts) => client.createInvite(space.id, resource.id, options, unref(graphRoles), opts)
+    )
 
     addCollaboratorShares([share])
     updateFileShareTypes(resource.id)
@@ -161,7 +231,10 @@ export const useSharesStore = defineStore('shares', () => {
     space,
     resource,
     collaboratorShare,
-    options
+    options,
+    graphRequestOptions,
+    confirmSharingHierarchyConflict,
+    informSharingHierarchyConflict
   }: UpdateShareOptions) => {
     const client = clientService.graphAuthenticated.permissions
 
@@ -170,12 +243,20 @@ export const useSharesStore = defineStore('shares', () => {
       expirationDateTime: options.expirationDateTime
     } satisfies Permission
 
-    const share = await client.updatePermission<CollaboratorShare>(
-      space.id,
-      resource.id,
-      collaboratorShare.id,
-      payload,
-      unref(graphRoles)
+    const share = await withShareHierarchyForceRetry(
+      graphRequestOptions,
+      confirmSharingHierarchyConflict,
+      informSharingHierarchyConflict,
+      undefined,
+      (opts) =>
+        client.updatePermission<CollaboratorShare>(
+          space.id,
+          resource.id,
+          collaboratorShare.id,
+          payload,
+          unref(graphRoles),
+          opts
+        )
     )
 
     upsertCollaboratorShare(share)
@@ -187,11 +268,20 @@ export const useSharesStore = defineStore('shares', () => {
     space,
     resource,
     collaboratorShare,
-    loadIndicators = false
+    loadIndicators = false,
+    graphRequestOptions,
+    confirmSharingHierarchyConflict,
+    informSharingHierarchyConflict
   }: DeleteShareOptions) => {
     const client = clientService.graphAuthenticated.permissions
 
-    await client.deletePermission(space.id, resource.id, collaboratorShare.id)
+    await withShareHierarchyForceRetry(
+      graphRequestOptions,
+      confirmSharingHierarchyConflict,
+      informSharingHierarchyConflict,
+      undefined,
+      (opts) => client.deletePermission(space.id, resource.id, collaboratorShare.id, opts)
+    )
 
     removeCollaboratorShare(collaboratorShare)
     updateFileShareTypes(resource.id)
@@ -270,7 +360,7 @@ export const useSharesStore = defineStore('shares', () => {
               grantedToIdentities: [
                 {
                   group: {
-                    displayName: "",
+                    displayName: '',
                     id: linkShare.notifyUploadsExtraRecipients
                   }
                 }

--- a/packages/web-pkg/src/composables/piniaStores/shares/types.ts
+++ b/packages/web-pkg/src/composables/piniaStores/shares/types.ts
@@ -1,13 +1,24 @@
-import { Resource } from '@ownclouders/web-client'
-import { ClientService } from '../../../services'
-import { CollaboratorShare, LinkShare, SpaceResource } from '@ownclouders/web-client'
+import {
+  CollaboratorShare,
+  LinkShare,
+  Resource,
+  SpaceResource,
+  type ConfirmSharingHierarchyConflict,
+  type GraphRequestOptions,
+  type InformSharingHierarchyConflict
+} from '@ownclouders/web-client'
 import { DriveItemCreateLink, DriveItemInvite } from '@ownclouders/web-client/graph/generated'
-
+import { ClientService } from '../../../services'
 export interface AddShareOptions {
   clientService: ClientService
   space: SpaceResource
   resource: Resource
   options: DriveItemInvite
+  graphRequestOptions?: GraphRequestOptions
+  confirmSharingHierarchyConflict?: ConfirmSharingHierarchyConflict
+  informSharingHierarchyConflict?: InformSharingHierarchyConflict
+  /** When true, 409 with `can_force` throws instead of opening a confirmation dialog (for batched invite UX). */
+  deferSharingHierarchyConflictConfirm?: boolean
 }
 
 export interface UpdateShareOptions {
@@ -16,6 +27,9 @@ export interface UpdateShareOptions {
   resource: Resource
   collaboratorShare: CollaboratorShare
   options: DriveItemInvite
+  graphRequestOptions?: GraphRequestOptions
+  confirmSharingHierarchyConflict?: ConfirmSharingHierarchyConflict
+  informSharingHierarchyConflict?: InformSharingHierarchyConflict
 }
 
 export interface DeleteShareOptions {
@@ -24,6 +38,9 @@ export interface DeleteShareOptions {
   resource: Resource
   collaboratorShare: CollaboratorShare
   loadIndicators?: boolean
+  graphRequestOptions?: GraphRequestOptions
+  confirmSharingHierarchyConflict?: ConfirmSharingHierarchyConflict
+  informSharingHierarchyConflict?: InformSharingHierarchyConflict
 }
 
 export interface AddLinkOptions {

--- a/packages/web-pkg/src/composables/shares/index.ts
+++ b/packages/web-pkg/src/composables/shares/index.ts
@@ -1,2 +1,4 @@
 export * from './useCanListShares'
 export * from './useCanShare'
+export * from './sharingHierarchyConflictDisplay'
+export * from './useSharingHierarchyConflictConfirm'

--- a/packages/web-pkg/src/composables/shares/sharingHierarchyConflictDisplay.ts
+++ b/packages/web-pkg/src/composables/shares/sharingHierarchyConflictDisplay.ts
@@ -1,0 +1,143 @@
+import type {
+  ShareRole,
+  SharingHierarchyConflict,
+  SharingHierarchyConflictingShare
+} from '@ownclouders/web-client'
+
+export type ShareeConflictGroup = {
+  shareeKey: string
+  shareeLabel: string
+  entries: {
+    key: string
+    permissionLabel: string
+    relativePath: string
+  }[]
+}
+
+type GettextFn = (msg: string, ctx?: Record<string, unknown>) => string
+
+export function collectConflictingShares(
+  conflicts: SharingHierarchyConflict[]
+): SharingHierarchyConflictingShare[] {
+  const seen = new Set<string>()
+  const shares: SharingHierarchyConflictingShare[] = []
+
+  for (const conflict of conflicts) {
+    for (const share of conflict.conflictingShares ?? []) {
+      const key = [share.id, share.path, share.sharee].filter(Boolean).join('|')
+      if (seen.has(key)) {
+        continue
+      }
+      seen.add(key)
+      shares.push(share)
+    }
+  }
+
+  return shares
+}
+
+export type SharingHierarchyConflictIntroVariant =
+  | 'default'
+  | 'redundant-direct-share'
+  | 'update-share'
+
+export function getSharingHierarchyConflictIntro(
+  conflicts: SharingHierarchyConflict[],
+  $gettext: GettextFn,
+  variant: SharingHierarchyConflictIntroVariant = 'default'
+): string {
+  const hasChildConflict = conflicts.some(
+    (c) => c.errorType === 'child_conflict' || (c.canForce && c.errorType !== 'parent_conflict')
+  )
+  const hasParentConflict = conflicts.some((c) => c.errorType === 'parent_conflict')
+
+  if (variant === 'redundant-direct-share' && hasParentConflict) {
+    return $gettext(
+      'This permission change conflicts with access through a parent folder. Remove this direct share if it is no longer needed.'
+    )
+  }
+
+  if (hasChildConflict && !hasParentConflict) {
+    return variant === 'update-share'
+      ? $gettext(
+          'Updating this share will replace any existing shares on contained subfolders and files. Please confirm to continue.'
+        )
+      : $gettext(
+          'Creating this share will replace any existing shares on contained subfolders and files. Please confirm to continue.'
+        )
+  }
+
+  if (hasParentConflict && !hasChildConflict) {
+    return $gettext(
+      'This share cannot be created because access already exists through a parent folder.'
+    )
+  }
+
+  return $gettext('The following sharing changes conflict with existing shares.')
+}
+
+export function formatRelativeSharePath(
+  share: SharingHierarchyConflictingShare,
+  resourcePath?: string
+): string {
+  const sharePath = share.path?.replace(/\/+$/, '')
+  if (!sharePath) {
+    return share.resourceId ?? share.id ?? ''
+  }
+
+  const basePath = resourcePath?.replace(/\/+$/, '')
+  if (basePath) {
+    if (sharePath === basePath) {
+      return './'
+    }
+    if (sharePath.startsWith(`${basePath}/`)) {
+      return sharePath.slice(basePath.length + 1)
+    }
+  }
+
+  const segments = share.path?.split('/').filter(Boolean) ?? []
+  const leaf = segments[segments.length - 1]
+  return leaf ?? sharePath
+}
+
+export function resolveConflictPermissionLabel(
+  share: SharingHierarchyConflictingShare,
+  graphRoles: Record<string, ShareRole>,
+  $gettext: GettextFn
+): string {
+  const perm = share.permissionType
+  if (!perm) {
+    return $gettext('Unknown permission')
+  }
+
+  const matchedRole = graphRoles[perm]
+
+  return matchedRole?.displayName ? $gettext(matchedRole.displayName) : perm
+}
+
+export function groupConflictingSharesBySharee(
+  shares: SharingHierarchyConflictingShare[],
+  resourcePath: string | undefined,
+  graphRoles: Record<string, ShareRole>,
+  $gettext: GettextFn
+): ShareeConflictGroup[] {
+  const groups = new Map<string, ShareeConflictGroup>()
+
+  shares.forEach((share, index) => {
+    const shareeKey = share.sharee || `unknown-${index}`
+    const shareeLabel = share.sharee || $gettext('Unknown user')
+
+    if (!groups.has(shareeKey)) {
+      groups.set(shareeKey, { shareeKey, shareeLabel, entries: [] })
+    }
+
+    const group = groups.get(shareeKey)!
+    group.entries.push({
+      key: `${shareeKey}-${share.id ?? share.path ?? index}`,
+      permissionLabel: resolveConflictPermissionLabel(share, graphRoles, $gettext),
+      relativePath: formatRelativeSharePath(share, resourcePath)
+    })
+  })
+
+  return Array.from(groups.values())
+}

--- a/packages/web-pkg/src/composables/shares/useSharingHierarchyConflictConfirm.ts
+++ b/packages/web-pkg/src/composables/shares/useSharingHierarchyConflictConfirm.ts
@@ -1,0 +1,171 @@
+import type { ShareRole, SharingHierarchyConflict } from '@ownclouders/web-client'
+import { SharingHierarchyConflictRemoveShareError } from '@ownclouders/web-client'
+import { storeToRefs } from 'pinia'
+import { inject, unref, type Ref } from 'vue'
+import { Resource } from '@ownclouders/web-client'
+import { useGettext } from 'vue3-gettext'
+import SharingHierarchyConflictModal, {
+  type SharingHierarchyConflictModalResult
+} from '../../components/Modals/SharingHierarchyConflictModal.vue'
+import { useModals } from '../piniaStores/modals'
+import type { SharingHierarchyConflictIntroVariant } from './sharingHierarchyConflictDisplay'
+
+async function loadGraphRoles(): Promise<Record<string, ShareRole>> {
+  const { useSharesStore } = await import('../piniaStores/shares/shares')
+  const { graphRoles } = storeToRefs(useSharesStore())
+  return unref(graphRoles)
+}
+
+function dispatchSharingHierarchyConflictModal(
+  modalsStore: ReturnType<typeof useModals>,
+  {
+    title,
+    variation,
+    conflicts,
+    mode,
+    introVariant,
+    resourcePath,
+    graphRoles
+  }: {
+    title: string
+    variation: string
+    conflicts: SharingHierarchyConflict[]
+    mode: 'confirm' | 'inform' | 'inform-remove'
+    introVariant?: SharingHierarchyConflictIntroVariant
+    resourcePath?: string
+    graphRoles: Record<string, ShareRole>
+  }
+): Promise<SharingHierarchyConflictModalResult> {
+  return new Promise<SharingHierarchyConflictModalResult>((resolve, reject) => {
+    modalsStore.dispatchModal({
+      variation,
+      title,
+      hideActions: true,
+      customComponent: SharingHierarchyConflictModal,
+      customComponentAttrs: () => ({
+        conflicts,
+        mode,
+        introVariant: introVariant ?? 'default',
+        resourcePath,
+        graphRoles,
+        callbackFn: (result: SharingHierarchyConflictModalResult) => {
+          if (result === 'remove') {
+            reject(new SharingHierarchyConflictRemoveShareError())
+            return
+          }
+
+          resolve(mode === 'inform' || mode === 'inform-remove' ? false : result)
+        }
+      })
+    })
+  })
+}
+
+function resolveResourcePath(resource: Resource | Ref<Resource> | undefined): string | undefined {
+  if (!resource) {
+    return undefined
+  }
+
+  return unref(resource)?.path
+}
+
+function resolveInformMode(
+  conflict: SharingHierarchyConflict,
+  offerRemoveShare: boolean
+): 'inform' | 'inform-remove' {
+  if (offerRemoveShare && conflict.errorType === 'parent_conflict') {
+    return 'inform-remove'
+  }
+
+  return 'inform'
+}
+
+export type SharingHierarchyConflictConfirmOptions = {
+  /** Which copy to show for a forcible (child_conflict) confirmation. Defaults to 'default' (create wording). */
+  introVariant?: SharingHierarchyConflictIntroVariant
+}
+
+/**
+ * Shows a confirmation dialog when the server returns 409 with `can_force: true` for share mutations.
+ */
+export function useSharingHierarchyConflictConfirm(
+  options: SharingHierarchyConflictConfirmOptions = {}
+): (conflict: SharingHierarchyConflict) => Promise<boolean> {
+  const { $gettext } = useGettext()
+  const modalsStore = useModals()
+  const resource = inject<Resource | Ref<Resource>>('resource')
+  const { introVariant = 'default' } = options
+
+  return async (conflict: SharingHierarchyConflict) =>
+    dispatchSharingHierarchyConflictModal(modalsStore, {
+      title: $gettext('Sharing conflicts'),
+      variation: 'warning',
+      conflicts: [conflict],
+      mode: 'confirm',
+      introVariant,
+      resourcePath: resolveResourcePath(resource),
+      graphRoles: await loadGraphRoles()
+    }) as Promise<boolean>
+}
+
+/**
+ * Shows one confirmation dialog for multiple deferred hierarchy conflicts (e.g. batch invite).
+ */
+export function useSharingHierarchyConflictsConfirm(): (
+  conflicts: SharingHierarchyConflict[]
+) => Promise<boolean> {
+  const { $gettext } = useGettext()
+  const modalsStore = useModals()
+  const resource = inject<Resource | Ref<Resource>>('resource')
+  const confirmOne = useSharingHierarchyConflictConfirm()
+
+  return async (conflicts: SharingHierarchyConflict[]) => {
+    if (conflicts.length === 0) {
+      return true
+    }
+
+    if (conflicts.length === 1) {
+      return confirmOne(conflicts[0])
+    }
+
+    return dispatchSharingHierarchyConflictModal(modalsStore, {
+      title: $gettext('Sharing conflicts'),
+      variation: 'warning',
+      conflicts,
+      mode: 'confirm',
+      resourcePath: resolveResourcePath(resource),
+      graphRoles: await loadGraphRoles()
+    }) as Promise<boolean>
+  }
+}
+
+export type SharingHierarchyConflictInformOptions = {
+  /** Offer to remove a redundant direct share on `parent_conflict`. */
+  offerRemoveShare?: boolean
+}
+
+/**
+ * Shows an informational dialog when the server returns 409 with `can_force: false`.
+ */
+export function useSharingHierarchyConflictInform(
+  options: SharingHierarchyConflictInformOptions = {}
+): (conflict: SharingHierarchyConflict) => Promise<void> {
+  const { $gettext } = useGettext()
+  const modalsStore = useModals()
+  const resource = inject<Resource | Ref<Resource>>('resource')
+  const { offerRemoveShare = false } = options
+
+  return async (conflict: SharingHierarchyConflict) => {
+    const mode = resolveInformMode(conflict, offerRemoveShare)
+
+    await dispatchSharingHierarchyConflictModal(modalsStore, {
+      title: $gettext('Cannot share'),
+      variation: 'passive',
+      conflicts: [conflict],
+      mode,
+      introVariant: mode === 'inform-remove' ? 'redundant-direct-share' : 'default',
+      resourcePath: resolveResourcePath(resource),
+      graphRoles: await loadGraphRoles()
+    })
+  }
+}

--- a/packages/web-pkg/tests/unit/components/Modals/SharingHierarchyConflictModal.spec.ts
+++ b/packages/web-pkg/tests/unit/components/Modals/SharingHierarchyConflictModal.spec.ts
@@ -1,0 +1,150 @@
+import SharingHierarchyConflictModal from '../../../../src/components/Modals/SharingHierarchyConflictModal.vue'
+import { defaultComponentMocks, defaultPlugins, shallowMount } from '@ownclouders/web-test-helpers'
+import { mock } from 'vitest-mock-extended'
+import { Modal } from '../../../../src/composables/piniaStores'
+
+describe('SharingHierarchyConflictModal', () => {
+  it('renders grouped conflict list', () => {
+    const { wrapper } = getWrapper({
+      props: {
+        conflicts: [
+          {
+            kind: 'hierarchy_conflict',
+            errorType: 'child_conflict',
+            message: 'Child shares will be removed',
+            canForce: true,
+            conflictingShares: [
+              {
+                sharee: 'userA',
+                path: 'myfolder',
+                permissionType: 'Read'
+              }
+            ],
+            raw: {}
+          }
+        ]
+      }
+    })
+
+    expect(wrapper.find('[data-testid="sharing-hierarchy-conflict-list"]').exists()).toBe(true)
+    expect(wrapper.text()).toContain('Shared with userA:')
+    expect(wrapper.text()).toContain('(Read) myfolder')
+  })
+
+  it('shows Proceed anyway for a single confirm conflict', () => {
+    const { wrapper } = getWrapper()
+    expect(wrapper.vm.confirmLabel).toBe('Proceed anyway')
+  })
+
+  it('shows Proceed with all for multiple confirm conflicts', () => {
+    const { wrapper } = getWrapper({
+      props: {
+        conflicts: [
+          {
+            kind: 'hierarchy_conflict',
+            errorType: 'child_conflict',
+            message: 'A',
+            canForce: true,
+            raw: {}
+          },
+          {
+            kind: 'hierarchy_conflict',
+            errorType: 'child_conflict',
+            message: 'B',
+            canForce: true,
+            raw: {}
+          }
+        ]
+      }
+    })
+
+    expect(wrapper.vm.confirmLabel).toBe('Proceed with all')
+  })
+
+  it('shows OK only in inform mode', () => {
+    const { wrapper } = getWrapper({ props: { mode: 'inform' } })
+    expect(wrapper.vm.cancelLabel).toBe('OK')
+    expect(wrapper.find('.oc-modal-body-actions-confirm').exists()).toBe(false)
+  })
+
+  it('shows remove action in inform-remove mode', () => {
+    const { wrapper } = getWrapper({
+      props: {
+        mode: 'inform-remove',
+        introVariant: 'redundant-direct-share',
+        conflicts: [
+          {
+            kind: 'hierarchy_conflict',
+            errorType: 'parent_conflict',
+            message: 'Already shared through parent',
+            canForce: false,
+            raw: {}
+          }
+        ]
+      }
+    })
+
+    expect(wrapper.vm.cancelLabel).toBe('OK')
+    expect(wrapper.vm.confirmLabel).toBe('Remove this share')
+    expect(wrapper.vm.intro).toContain('Remove this direct share')
+  })
+
+  it('calls callback on confirm', async () => {
+    const callbackFn = vi.fn()
+    const { wrapper } = getWrapper({ props: { callbackFn } })
+    await wrapper.vm.onConfirm()
+    expect(callbackFn).toHaveBeenCalledWith(true)
+  })
+
+  it('calls callback with remove in inform-remove mode', async () => {
+    const callbackFn = vi.fn()
+    const { wrapper } = getWrapper({ props: { mode: 'inform-remove', callbackFn } })
+    await wrapper.vm.onConfirm()
+    expect(callbackFn).toHaveBeenCalledWith('remove')
+  })
+
+  it('calls callback on cancel', async () => {
+    const callbackFn = vi.fn()
+    const { wrapper } = getWrapper({ props: { callbackFn } })
+    await wrapper.vm.onCancel()
+    expect(callbackFn).toHaveBeenCalledWith(false)
+  })
+})
+
+function getWrapper({ props = {} } = {}) {
+  const mocks = defaultComponentMocks()
+
+  return {
+    mocks,
+    wrapper: shallowMount(SharingHierarchyConflictModal, {
+      props: {
+        modal: mock<Modal>({ id: 'modal-1' }),
+        mode: 'confirm',
+        graphRoles: {},
+        callbackFn: vi.fn(),
+        conflicts: [
+          {
+            kind: 'hierarchy_conflict',
+            errorType: 'child_conflict',
+            message: 'Child shares will be removed',
+            canForce: true,
+            conflictingShares: [
+              {
+                sharee: 'userA',
+                path: 'myfolder',
+                permissionType: 'Read'
+              }
+            ],
+            raw: {}
+          }
+        ],
+        ...props
+      },
+      global: {
+        plugins: [...defaultPlugins()],
+        mocks,
+        provide: mocks
+      }
+    })
+  }
+}

--- a/packages/web-pkg/tests/unit/composables/piniaStores/shares.spec.ts
+++ b/packages/web-pkg/tests/unit/composables/piniaStores/shares.spec.ts
@@ -1,4 +1,5 @@
 import { createTestingPinia, getComposableWrapper } from '@ownclouders/web-test-helpers'
+import { AxiosError } from 'axios'
 import {
   AddLinkOptions,
   AddShareOptions,
@@ -11,10 +12,59 @@ import {
 } from '../../../../src/composables/piniaStores'
 import { mock, mockDeep } from 'vitest-mock-extended'
 import { ClientService } from '../../../../src/services'
-import { CollaboratorShare, LinkShare, Resource } from '@ownclouders/web-client'
+import {
+  CollaboratorShare,
+  LinkShare,
+  Resource,
+  SHARE_HIERARCHY_FORCE_HEADER,
+  SharingHierarchyConflictRemoveShareError,
+  SpaceResource
+} from '@ownclouders/web-client'
 import { User } from '@ownclouders/web-client/graph/generated'
 
 describe('useSharesStore', () => {
+  const space = { id: 'space-1' } as SpaceResource
+
+  function conflict409() {
+    return new AxiosError(
+      'Conflict',
+      'ERR_BAD_REQUEST',
+      undefined,
+      {},
+      {
+        status: 409,
+        statusText: 'Conflict',
+        data: {
+          error_type: 'child_conflict',
+          message: 'x',
+          can_force: true
+        },
+        headers: {},
+        config: {} as any
+      }
+    )
+  }
+
+  function parentConflict409() {
+    return new AxiosError(
+      'Conflict',
+      'ERR_BAD_REQUEST',
+      undefined,
+      {},
+      {
+        status: 409,
+        statusText: 'Conflict',
+        data: {
+          error_type: 'parent_conflict',
+          message: 'Already shared through parent',
+          can_force: false
+        },
+        headers: {},
+        config: {} as any
+      }
+    )
+  }
+
   beforeEach(() => {
     createTestingPinia({
       stubActions: false,
@@ -36,12 +86,164 @@ describe('useSharesStore', () => {
           const userStore = useUserStore()
           userStore.user = user
 
-          await instance.addShare(mock<AddShareOptions>({ clientService, resource }))
+          await instance.addShare(mock<AddShareOptions>({ clientService, resource, space }))
 
           expect(clientService.graphAuthenticated.permissions.createInvite).toHaveBeenCalledTimes(1)
           expect(instance.collaboratorShares.length).toBe(1)
         }
       })
+    })
+
+    it('retries createInvite with force header when user confirms after 409', async () => {
+      const resource = { id: '1' } as Resource
+      const share = mock<CollaboratorShare>({ id: '1' })
+      const user = { id: '1' } as User
+
+      const clientService = mockDeep<ClientService>()
+      clientService.graphAuthenticated.permissions.createInvite
+        .mockRejectedValueOnce(conflict409())
+        .mockResolvedValueOnce(share)
+
+      const userStore = useUserStore()
+      userStore.user = user
+
+      const instance = useSharesStore()
+
+      await instance.addShare({
+        clientService,
+        resource,
+        space,
+        options: {} as AddShareOptions['options'],
+        confirmSharingHierarchyConflict: () => Promise.resolve(true),
+        deferSharingHierarchyConflictConfirm: false
+      })
+
+      expect(clientService.graphAuthenticated.permissions.createInvite).toHaveBeenCalledTimes(2)
+      expect(clientService.graphAuthenticated.permissions.createInvite).toHaveBeenLastCalledWith(
+        space.id,
+        resource.id,
+        expect.anything(),
+        expect.anything(),
+        expect.objectContaining({
+          headers: { [SHARE_HIERARCHY_FORCE_HEADER]: 'true' }
+        })
+      )
+      expect(instance.collaboratorShares.length).toBe(1)
+    })
+
+    it('throws pending error when deferSharingHierarchyConflictConfirm is set', async () => {
+      const resource = { id: '1' } as Resource
+      const user = { id: '1' } as User
+
+      const clientService = mockDeep<ClientService>()
+      clientService.graphAuthenticated.permissions.createInvite.mockRejectedValueOnce(conflict409())
+
+      const userStore = useUserStore()
+      userStore.user = user
+
+      const instance = useSharesStore()
+
+      await expect(
+        instance.addShare({
+          clientService,
+          resource,
+          space,
+          options: {} as AddShareOptions['options'],
+          deferSharingHierarchyConflictConfirm: true
+        })
+      ).rejects.toMatchObject({
+        name: 'SharingHierarchyConflictPendingError',
+        conflict: expect.objectContaining({ canForce: true })
+      })
+
+      expect(clientService.graphAuthenticated.permissions.createInvite).toHaveBeenCalledTimes(1)
+    })
+
+    it('shows inform dialog and throws blocked error on parent conflict', async () => {
+      const resource = { id: '1' } as Resource
+      const user = { id: '1' } as User
+
+      const clientService = mockDeep<ClientService>()
+      clientService.graphAuthenticated.permissions.createInvite.mockRejectedValueOnce(
+        parentConflict409()
+      )
+
+      const userStore = useUserStore()
+      userStore.user = user
+
+      const instance = useSharesStore()
+      const inform = vi.fn().mockResolvedValue(undefined)
+
+      await expect(
+        instance.addShare({
+          clientService,
+          resource,
+          space,
+          options: {} as AddShareOptions['options'],
+          informSharingHierarchyConflict: inform
+        })
+      ).rejects.toMatchObject({ name: 'SharingHierarchyConflictBlockedError' })
+
+      expect(inform).toHaveBeenCalledTimes(1)
+      expect(clientService.graphAuthenticated.permissions.createInvite).toHaveBeenCalledTimes(1)
+    })
+
+    it('throws cancelled error when user declines force confirmation', async () => {
+      const resource = { id: '1' } as Resource
+      const user = { id: '1' } as User
+
+      const clientService = mockDeep<ClientService>()
+      clientService.graphAuthenticated.permissions.createInvite.mockRejectedValueOnce(conflict409())
+
+      const userStore = useUserStore()
+      userStore.user = user
+
+      const instance = useSharesStore()
+
+      await expect(
+        instance.addShare({
+          clientService,
+          resource,
+          space,
+          options: {} as AddShareOptions['options'],
+          confirmSharingHierarchyConflict: () => Promise.resolve(false)
+        })
+      ).rejects.toMatchObject({ name: 'SharingHierarchyConflictCancelledError' })
+
+      expect(clientService.graphAuthenticated.permissions.createInvite).toHaveBeenCalledTimes(1)
+    })
+
+    it('propagates remove share choice from inform callback on parent conflict', async () => {
+      const resource = { id: '1' } as Resource
+      const share = mock<CollaboratorShare>({ id: 'share-1' })
+      const user = { id: '1' } as User
+
+      const clientService = mockDeep<ClientService>()
+      clientService.graphAuthenticated.permissions.updatePermission
+        .mockRejectedValueOnce(parentConflict409())
+        .mockResolvedValueOnce(share)
+
+      const userStore = useUserStore()
+      userStore.user = user
+
+      const instance = useSharesStore()
+      const inform = vi
+        .fn()
+        .mockRejectedValue(new SharingHierarchyConflictRemoveShareError())
+
+      await expect(
+        instance.updateShare({
+          clientService,
+          resource,
+          space,
+          collaboratorShare: share,
+          options: {} as UpdateShareOptions['options'],
+          informSharingHierarchyConflict: inform
+        })
+      ).rejects.toMatchObject({ name: 'SharingHierarchyConflictRemoveShareError' })
+
+      expect(inform).toHaveBeenCalledTimes(1)
+      expect(clientService.graphAuthenticated.permissions.updatePermission).toHaveBeenCalledTimes(1)
     })
   })
   describe('updateShare', () => {

--- a/packages/web-pkg/tests/unit/composables/shares/sharingHierarchyConflictDisplay.spec.ts
+++ b/packages/web-pkg/tests/unit/composables/shares/sharingHierarchyConflictDisplay.spec.ts
@@ -1,0 +1,200 @@
+import { describe, expect, it } from 'vitest'
+import type { ShareRole } from '@ownclouders/web-client'
+import {
+  collectConflictingShares,
+  formatRelativeSharePath,
+  getSharingHierarchyConflictIntro,
+  groupConflictingSharesBySharee,
+  resolveConflictPermissionLabel
+} from '../../../../src/composables/shares/sharingHierarchyConflictDisplay'
+
+const $gettext = (msg: string) => msg
+
+const graphRoles: Record<string, ShareRole> = {
+  viewer: { id: 'viewer', displayName: 'Can view', description: '' },
+  editor: { id: 'editor', displayName: 'Can edit', description: '' },
+  denied: { id: 'denied', displayName: 'Cannot access', description: '' }
+}
+
+describe('sharingHierarchyConflictDisplay', () => {
+  describe('getSharingHierarchyConflictIntro', () => {
+    it('uses child conflict copy when only child conflicts exist', () => {
+      const intro = getSharingHierarchyConflictIntro(
+        [
+          {
+            kind: 'hierarchy_conflict',
+            errorType: 'child_conflict',
+            message: '',
+            canForce: true,
+            raw: {}
+          }
+        ],
+        $gettext
+      )
+
+      expect(intro).toContain('replace any existing shares')
+    })
+
+  it('uses parent conflict copy when only parent conflicts exist', () => {
+    const intro = getSharingHierarchyConflictIntro(
+      [
+        {
+          kind: 'hierarchy_conflict',
+          errorType: 'parent_conflict',
+          message: '',
+          canForce: false,
+          raw: {}
+        }
+      ],
+      $gettext
+    )
+
+    expect(intro).toContain('cannot be created')
+  })
+
+  it('uses redundant direct share copy for role update conflicts', () => {
+    const intro = getSharingHierarchyConflictIntro(
+      [
+        {
+          kind: 'hierarchy_conflict',
+          errorType: 'parent_conflict',
+          message: '',
+          canForce: false,
+          raw: {}
+        }
+      ],
+      $gettext,
+      'redundant-direct-share'
+    )
+
+    expect(intro).toContain('Remove this direct share')
+  })
+
+  it('uses "Updating" copy for a forcible child conflict with the update-share variant', () => {
+    const intro = getSharingHierarchyConflictIntro(
+      [
+        {
+          kind: 'hierarchy_conflict',
+          errorType: 'child_conflict',
+          message: '',
+          canForce: true,
+          raw: {}
+        }
+      ],
+      $gettext,
+      'update-share'
+    )
+
+    expect(intro).toContain('Updating this share will replace any existing shares')
+  })
+  })
+
+  describe('formatRelativeSharePath', () => {
+    it('strips resource path prefix from absolute path', () => {
+      expect(
+        formatRelativeSharePath(
+          { path: '/spaces/project/myfolder' },
+          '/spaces/project'
+        )
+      ).toBe('myfolder')
+    })
+
+    it('does not append a trailing slash for a file share', () => {
+      expect(
+        formatRelativeSharePath(
+          { path: '/spaces/project/myfile.txt' },
+          '/spaces/project'
+        )
+      ).toBe('myfile.txt')
+    })
+  })
+
+  describe('resolveConflictPermissionLabel', () => {
+    it('matches the configured role by id (permission_type is a graphRoles key)', () => {
+      expect(
+        resolveConflictPermissionLabel({ permissionType: 'viewer' }, graphRoles, $gettext)
+      ).toBe('Can view')
+    })
+
+    it('matches a different configured role by id', () => {
+      expect(
+        resolveConflictPermissionLabel({ permissionType: 'editor' }, graphRoles, $gettext)
+      ).toBe('Can edit')
+    })
+
+    it('matches the denied role by id', () => {
+      expect(
+        resolveConflictPermissionLabel({ permissionType: 'denied' }, graphRoles, $gettext)
+      ).toBe('Cannot access')
+    })
+
+    it('falls back to the raw permission_type when no configured role matches', () => {
+      expect(
+        resolveConflictPermissionLabel({ permissionType: 'unknown-role-id' }, graphRoles, $gettext)
+      ).toBe('unknown-role-id')
+    })
+
+    it('returns "Unknown permission" when no permission_type is given', () => {
+      expect(resolveConflictPermissionLabel({}, graphRoles, $gettext)).toBe('Unknown permission')
+    })
+  })
+
+  describe('groupConflictingSharesBySharee', () => {
+    it('groups entries under sharee labels', () => {
+      const groups = groupConflictingSharesBySharee(
+        [
+          {
+            sharee: 'userA',
+            path: '/spaces/project/myfolder',
+            permissionType: 'viewer'
+          },
+          {
+            sharee: 'userA',
+            path: '/spaces/project/other',
+            permissionType: 'editor'
+          },
+          {
+            sharee: 'userB',
+            path: '/spaces/project/docs',
+            permissionType: 'viewer'
+          }
+        ],
+        '/spaces/project',
+        graphRoles,
+        $gettext
+      )
+
+      expect(groups).toHaveLength(2)
+      expect(groups[0].shareeLabel).toBe('userA')
+      expect(groups[0].entries).toHaveLength(2)
+      expect(groups[1].shareeLabel).toBe('userB')
+      expect(groups[1].entries[0].permissionLabel).toBe('Can view')
+    })
+  })
+
+  describe('collectConflictingShares', () => {
+    it('deduplicates shares across conflicts', () => {
+      const share = { id: '1', path: '/a', sharee: 'user' }
+      const collected = collectConflictingShares([
+        {
+          kind: 'hierarchy_conflict',
+          errorType: 'child_conflict',
+          message: '',
+          canForce: true,
+          conflictingShares: [share],
+          raw: {}
+        },
+        {
+          kind: 'hierarchy_conflict',
+          errorType: 'child_conflict',
+          message: '',
+          canForce: true,
+          conflictingShares: [share],
+          raw: {}
+        }
+      ])
+
+      expect(collected).toHaveLength(1)
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Implements the **ownCloud Web** side of ADR-0005 hierarchical sharing conflicts for collaborator share mutations via Graph.

When Reva rejects a create/update share with **HTTP 409** and a structured JSON body, the UI:

- Shows an **error** for hard conflicts (`parent_conflict`, `can_force: false`)
- Shows a **confirmation dialog** for warnings (`child_conflict`, `can_force: true`)
- **Retries the same mutation** with the `Force: true` header after the user confirms

**Backend contract:** targets Jesse Geens' Reva branch [`feat/share-consistency`](https://github.com/cs3org/reva/pull/5562). Deploy **web and Reva together**.

### Behaviour

| Mutation | Entry point | Conflict handling |
|----------|-------------|-------------------|
| **Create** (invite) | `InviteCollaboratorForm` | Deferred batch: collect all `child_conflict` 409s during parallel invites, show **one** combined modal, then re-issue failed invites with `Force: true` |
| **Update** | `ListItem` (role/expiry) | Per-action confirm modal → retry with `Force: true` |
| **Delete** | `FileShares`, `SpaceMembers` | Same retry wrapper (latent until Reva exposes hierarchy 409 on DELETE) |

### Reva JSON contract (409)

```json
{
  "error_type": "parent_conflict | child_conflict",
  "message": "...",
  "can_force": true,
  "conflicting_shares": [{ "id", "resource_id", "path", "permission_type" }]
}